### PR TITLE
Migrate x-text/:text bindings to {{ }} interpolation (stx 0.2.72)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,9 +7,9 @@
       "dependencies": {
         "@cwcss/crosswind": "^0.2.6",
         "@stacksjs/bun-router": "^0.0.16",
-        "@stacksjs/components": "^0.2.67",
-        "@stacksjs/stx": "^0.2.70",
-        "bun-plugin-stx": "^0.2.70",
+        "@stacksjs/components": "^0.2.72",
+        "@stacksjs/stx": "^0.2.72",
+        "bun-plugin-stx": "^0.2.72",
         "bun-query-builder": "^0.1.13",
         "dynamodb-tooling": "^0.3.2",
         "ts-countries": "^0.1.2",
@@ -41,9 +41,9 @@
 
     "@stacksjs/clarity": ["@stacksjs/clarity@0.3.28", "", { "dependencies": { "bunfig": "^0.15.6" }, "bin": { "clarity": "./dist/bin/cli.js" } }, "sha512-SElzGeDewEbp0c4C8PTfdvi/Xtr1HGAjG6b0prHvkVxyYGM+2R0BFU0otUmy+DbR7wsfZ4rNU3YN1+JK/CzoTw=="],
 
-    "@stacksjs/components": ["@stacksjs/components@0.2.70", "", { "dependencies": { "@cwcss/crosswind": "^0.2.0", "@stacksjs/stx": "0.2.70", "bun-plugin-stx": "0.2.70", "ts-syntax-highlighter": "^0.2.1" } }, "sha512-1yDmqRwKxNY073Rw2RiESWMHplXNP6ITrERquDjcCNCoS3vPqHsnItrJ9XEuYOnKtfAHNEhIVuGM738d1Km/PQ=="],
+    "@stacksjs/components": ["@stacksjs/components@0.2.72", "", { "dependencies": { "@cwcss/crosswind": "^0.2.0", "@stacksjs/stx": "0.2.72", "bun-plugin-stx": "0.2.72", "ts-syntax-highlighter": "^0.2.1" } }, "sha512-g1F7UYVSD13vQHx1U+/U2bor10OqUmC/C6Yh+uwrCmh+l6Vt4T52VLWPNPETQow8zCjqX5/Xme4HZqYm3HC/xw=="],
 
-    "@stacksjs/desktop": ["@stacksjs/desktop@0.2.70", "", { "peerDependencies": { "craft": "*" }, "optionalPeers": ["craft"] }, "sha512-tBwE98HT+bajYzm4oY2NZtXz5+c9DjX6rUVXs0d8vr3Kv/4pof6tx+GTw64Z+lqvdB8wgCISRduDIVZiZjyDWQ=="],
+    "@stacksjs/desktop": ["@stacksjs/desktop@0.2.72", "", { "peerDependencies": { "craft": "*" }, "optionalPeers": ["craft"] }, "sha512-R436Ag4EdDhzM96idRHF61R+FkhwbtRbalQzEV/TRSYCMwJpVwJju5gQA08u+5elEZgCGATjtUia4GBbnJKWCw=="],
 
     "@stacksjs/dtsx": ["@stacksjs/dtsx@0.9.26", "", { "dependencies": { "@stacksjs/clapp": "^0.2.0" }, "peerDependencies": { "typescript": ">=5.9.3" }, "bin": { "dtsx": "./dist/bin/cli.js" } }, "sha512-MOUxZn8BhXpFYM+vh7cnQLUOLjZ4G6q76V+4OypkRiu/Gvpek9ywBQLbmv8iWLjT6gXlFMpEdw33o3GKKLpMCw=="],
 
@@ -51,9 +51,9 @@
 
     "@stacksjs/logsmith": ["@stacksjs/logsmith@0.2.3", "", { "dependencies": { "@stacksjs/clapp": "^0.2.0", "bunfig": "^0.15.6", "pickier": "^0.1.9" }, "bin": { "@stacksjs/logsmith": "./dist/bin/cli.js", "logsmith": "./dist/bin/cli.js" } }, "sha512-Jy2AHVdEQwDtjlOVSG4xOmIMSy/D2iZcPK7KaoDOmKfZbMmfmbhveK16w1TWKCY9duhMZigdpeFx39ZzXGARVg=="],
 
-    "@stacksjs/sanitizer": ["@stacksjs/sanitizer@0.2.70", "", {}, "sha512-jRuRn0VyCmlqM9H2yOuChV1dkxBozW+THBAnGcraYzPjf5CD1x/tRz9PGzS8h6PlEUSBfBi2zr+wPEwUKj1GoA=="],
+    "@stacksjs/sanitizer": ["@stacksjs/sanitizer@0.2.72", "", {}, "sha512-66a3QSfuSAgDDZJ3Z/mgqHEtkYwfag1m+9636I4X5cveTA69O92/0aEp6+f5MgGfPA+Gv4gkl3ArP8FBslR0BQ=="],
 
-    "@stacksjs/stx": ["@stacksjs/stx@0.2.70", "", { "dependencies": { "@cwcss/crosswind": "^0.2.0", "@stacksjs/clapp": "^0.2.0", "@stacksjs/desktop": "0.2.70", "@stacksjs/sanitizer": "0.2.70", "@stacksjs/ts-craft": "^0.0.2", "bun-plugin-stx": "0.2.70", "bunfig": "^0.15.6", "stx-router": "0.2.70", "ts-broadcasting": "^0.0.4", "ts-images": "^0.1.8", "ts-syntax-highlighter": "^0.2.1" }, "bin": { "stx": "./dist/cli.js" } }, "sha512-dPOj5qvaZLQGKd3PlZawH/qL9IiUFUaSIKVpjUFp4/fqeOpdA7QbPC5vWhyYCeVa+tHyQwetBndwwjCYAHPjOw=="],
+    "@stacksjs/stx": ["@stacksjs/stx@0.2.72", "", { "dependencies": { "@cwcss/crosswind": "^0.2.0", "@stacksjs/clapp": "^0.2.0", "@stacksjs/desktop": "0.2.72", "@stacksjs/sanitizer": "0.2.72", "@stacksjs/ts-craft": "^0.0.2", "@stacksjs/ts-i18n": "^0.1.11", "bun-plugin-stx": "0.2.72", "bunfig": "^0.15.6", "stx-router": "0.2.72", "ts-broadcasting": "^0.0.4", "ts-images": "^0.1.8", "ts-syntax-highlighter": "^0.2.1" }, "bin": { "stx": "./dist/cli.js" } }, "sha512-aW6w0epktzFz0Jai9vCctBXEkPcri42jYNrojHyEm0oaRxyEgq9BLn6K5GUljLoJprr6wzfbDHZQp4FCopakaw=="],
 
     "@stacksjs/ts-avif": ["@stacksjs/ts-avif@0.1.0", "", {}, "sha512-ytcta6ZhZeZwXJTcWlTraNLBsqL4imOfruSkJ2PwEp5RjHb4eSoqb21W4u7HLILRcILr7B1nOkIMeQct4Pozbw=="],
 
@@ -66,6 +66,8 @@
     "@stacksjs/ts-css": ["@stacksjs/ts-css@0.1.0", "", { "dependencies": { "bunfig": "^0.15.6" }, "bin": { "ts-css": "./dist/bin/cli.js" } }, "sha512-373WvzZeXdqwi6lRwyfr05r3KOtbo4QXWPhmoGFI6NSa5ZcUEiyYJGL2KsV9mfQNTsBp+0q3wPnj1EQ/1zuieg=="],
 
     "@stacksjs/ts-faker": ["@stacksjs/ts-faker@0.1.8", "", { "dependencies": { "@stacksjs/clapp": "^0.2.0" }, "bin": { "@stacksjs/ts-faker": "dist/bin/cli.js", "faker": "dist/bin/cli.js", "fake": "dist/bin/cli.js", "mock": "dist/bin/cli.js" } }, "sha512-YEOIr9mlMeXodcl8FmX3Rq7fqZDcubi7nwdl7lCKr682GIimOQjdN8miQmVEgbBYlpwP1cOn8eO6DhVotMwWnw=="],
+
+    "@stacksjs/ts-i18n": ["@stacksjs/ts-i18n@0.1.11", "", { "dependencies": { "@stacksjs/clapp": "^0.2.9", "bunfig": "^0.15.6" }, "bin": { "i18n": "./dist/cli.js" } }, "sha512-33FM0gKdxBy6EUsUZLGAMe0D7QUZ4f/BQXRsQIyzkZgs2+juruUTevPuJGCjWSZsgJuiaBfEJn8Oq8ctuo1OWQ=="],
 
     "@stacksjs/ts-md": ["@stacksjs/ts-md@0.1.1", "", { "bin": { "md": "./bin/cli.ts" } }, "sha512-kvsSg7S3vHq65fnHIRggTLudN4n1sjkos86xLB62V6PVRa8iosYAmFKVDTGaJk+0MdsIoRwQbJ2vLWVcNQsgGw=="],
 
@@ -135,7 +137,7 @@
 
     "bun-plugin-dtsx": ["bun-plugin-dtsx@0.9.26", "", { "dependencies": { "@stacksjs/dtsx": "0.9.26" } }, "sha512-dOlA+gx3mju+Be0uoZqsuQ3U+GPu08wv7QQwA1k569tw8Bv9GwVWJz0jjQw6tzJi9Rvwfl31MVXu9rHYQXSKow=="],
 
-    "bun-plugin-stx": ["bun-plugin-stx@0.2.70", "", { "dependencies": { "@stacksjs/stx": "0.2.70", "stx-router": "0.2.70" }, "bin": { "serve": "./dist/serve.js", "stx-serve": "./dist/serve.js" } }, "sha512-7bJ6uzQLWqNM5p9Pgha9fNhVTz0gBT4LJyXEEmkMOIljevp7zKiWBa0r2F1CM0eXqSlUfqgI659mtfkhB9MiSA=="],
+    "bun-plugin-stx": ["bun-plugin-stx@0.2.72", "", { "dependencies": { "@stacksjs/stx": "0.2.72", "stx-router": "0.2.72" }, "bin": { "serve": "./dist/serve.js", "stx-serve": "./dist/serve.js" } }, "sha512-vkvFCmAm+w1YpCCBD5EImLaGFxgJmKZWDdi4mBvO9lxMFXBZiDyGcFxPnWGTdXcw2S085+lEG32BHwCV9kiqmw=="],
 
     "bun-query-builder": ["bun-query-builder@0.1.37", "", { "dependencies": { "@stacksjs/clapp": "^0.2.0", "@stacksjs/ts-faker": "^0.1.8", "@stacksjs/ts-validation": "^0.5.0", "dynamodb-tooling": "^0.3.2" }, "bin": { "query-builder": "./dist/bin/cli.js", "qbx": "./dist/bin/cli.js", "qb": "./dist/bin/cli.js" } }, "sha512-IWgItHagukC4lf/11YmvccNrSEeX1wKeMiNTbUuw71c29Ru+3G2RD4kAPAVjZxkqLglrkyHRUM0iZ1c3yTdT1w=="],
 
@@ -249,7 +251,7 @@
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "stx-router": ["stx-router@0.2.70", "", {}, "sha512-b0tF8pmqVsgC0I0epav9NURHJk48vVe62QfQFK0jQiVBnAYTJREgjRK9gdrCxIIX/DAmoyI39zsYoKzv/tyiAQ=="],
+    "stx-router": ["stx-router@0.2.72", "", {}, "sha512-WUr5XaZVWp4JifqqOzU7YhmxIAiEPO8iRFO81VhKaGlF+FHrTPzhh3O0AmkAN+kmHv+IajbJ1UpMIcPTa5nFEg=="],
 
     "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
 
@@ -291,9 +293,7 @@
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
-    "@stacksjs/components/@cwcss/crosswind": ["@cwcss/crosswind@0.2.4", "", { "dependencies": { "@stacksjs/clapp": "^0.2.0", "bunfig": "^0.15.0" }, "bin": { "crosswind": "./dist/cli.js" } }, "sha512-LKcLryQl7Ue4LTbS3l1pBgcr2t4wIXdBtEJB1nlW5uJmS1o+cwR1uMASb2r9b1mtmfkp4xIouSRUvRRGAGbxww=="],
-
-    "@stacksjs/stx/@cwcss/crosswind": ["@cwcss/crosswind@0.2.4", "", { "dependencies": { "@stacksjs/clapp": "^0.2.0", "bunfig": "^0.15.0" }, "bin": { "crosswind": "./dist/cli.js" } }, "sha512-LKcLryQl7Ue4LTbS3l1pBgcr2t4wIXdBtEJB1nlW5uJmS1o+cwR1uMASb2r9b1mtmfkp4xIouSRUvRRGAGbxww=="],
+    "@stacksjs/bunpress/@stacksjs/stx": ["@stacksjs/stx@0.2.70", "", { "dependencies": { "@cwcss/crosswind": "^0.2.0", "@stacksjs/clapp": "^0.2.0", "@stacksjs/desktop": "0.2.70", "@stacksjs/sanitizer": "0.2.70", "@stacksjs/ts-craft": "^0.0.2", "bun-plugin-stx": "0.2.70", "bunfig": "^0.15.6", "stx-router": "0.2.70", "ts-broadcasting": "^0.0.4", "ts-images": "^0.1.8", "ts-syntax-highlighter": "^0.2.1" }, "bin": { "stx": "./dist/cli.js" } }, "sha512-dPOj5qvaZLQGKd3PlZawH/qL9IiUFUaSIKVpjUFp4/fqeOpdA7QbPC5vWhyYCeVa+tHyQwetBndwwjCYAHPjOw=="],
 
     "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -310,6 +310,16 @@
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@stacksjs/bunpress/@stacksjs/stx/@cwcss/crosswind": ["@cwcss/crosswind@0.2.4", "", { "dependencies": { "@stacksjs/clapp": "^0.2.0", "bunfig": "^0.15.0" }, "bin": { "crosswind": "./dist/cli.js" } }, "sha512-LKcLryQl7Ue4LTbS3l1pBgcr2t4wIXdBtEJB1nlW5uJmS1o+cwR1uMASb2r9b1mtmfkp4xIouSRUvRRGAGbxww=="],
+
+    "@stacksjs/bunpress/@stacksjs/stx/@stacksjs/desktop": ["@stacksjs/desktop@0.2.70", "", { "peerDependencies": { "craft": "*" }, "optionalPeers": ["craft"] }, "sha512-tBwE98HT+bajYzm4oY2NZtXz5+c9DjX6rUVXs0d8vr3Kv/4pof6tx+GTw64Z+lqvdB8wgCISRduDIVZiZjyDWQ=="],
+
+    "@stacksjs/bunpress/@stacksjs/stx/@stacksjs/sanitizer": ["@stacksjs/sanitizer@0.2.70", "", {}, "sha512-jRuRn0VyCmlqM9H2yOuChV1dkxBozW+THBAnGcraYzPjf5CD1x/tRz9PGzS8h6PlEUSBfBi2zr+wPEwUKj1GoA=="],
+
+    "@stacksjs/bunpress/@stacksjs/stx/bun-plugin-stx": ["bun-plugin-stx@0.2.70", "", { "dependencies": { "@stacksjs/stx": "0.2.70", "stx-router": "0.2.70" }, "bin": { "serve": "./dist/serve.js", "stx-serve": "./dist/serve.js" } }, "sha512-7bJ6uzQLWqNM5p9Pgha9fNhVTz0gBT4LJyXEEmkMOIljevp7zKiWBa0r2F1CM0eXqSlUfqgI659mtfkhB9MiSA=="],
+
+    "@stacksjs/bunpress/@stacksjs/stx/stx-router": ["stx-router@0.2.70", "", {}, "sha512-b0tF8pmqVsgC0I0epav9NURHJk48vVe62QfQFK0jQiVBnAYTJREgjRK9gdrCxIIX/DAmoyI39zsYoKzv/tyiAQ=="],
 
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
   "dependencies": {
     "@cwcss/crosswind": "^0.2.6",
     "@stacksjs/bun-router": "^0.0.16",
-    "@stacksjs/components": "^0.2.67",
-    "@stacksjs/stx": "^0.2.70",
-    "bun-plugin-stx": "^0.2.70",
+    "@stacksjs/components": "^0.2.72",
+    "@stacksjs/stx": "^0.2.72",
+    "bun-plugin-stx": "^0.2.72",
     "bun-query-builder": "^0.1.13",
     "dynamodb-tooling": "^0.3.2",
     "ts-countries": "^0.1.2"

--- a/resources/components/dashboard/AccountSettings.stx
+++ b/resources/components/dashboard/AccountSettings.stx
@@ -107,8 +107,8 @@ onMount(() => {
 <div class="col-span-full max-w-[640px]">
   <h3 class="text-base font-semibold text-text mb-1">Account</h3>
   <p class="text-xs text-muted mb-6">
-    Signed in as <span class="text-text" x-text="email()"></span>
-    <span class="text-[0.625rem] font-semibold py-0.5 px-[7px] rounded uppercase tracking-wide bg-bg-3 text-text-2 ml-1" x-text="plan()"></span>
+    Signed in as <span class="text-text">{{ email() }}</span>
+    <span class="text-[0.625rem] font-semibold py-0.5 px-[7px] rounded uppercase tracking-wide bg-bg-3 text-text-2 ml-1">{{ plan() }}</span>
     <span x-show="!emailVerified()" class="text-warning ml-1">— email not verified</span>
   </p>
 
@@ -121,8 +121,8 @@ onMount(() => {
       </div>
       <button type="submit" class="btn btn-primary text-[0.8125rem] py-2 px-4">Save</button>
     </form>
-    <p x-show="profileMsg()" class="text-xs text-success mt-2" x-text="profileMsg()"></p>
-    <p x-show="profileErr()" class="text-xs text-error mt-2" x-text="profileErr()"></p>
+    <p x-show="profileMsg()" class="text-xs text-success mt-2">{{ profileMsg() }}</p>
+    <p x-show="profileErr()" class="text-xs text-error mt-2">{{ profileErr() }}</p>
   </div>
 
   <div class="panel mb-4">
@@ -138,8 +138,8 @@ onMount(() => {
       </div>
       <button type="submit" class="btn btn-primary text-[0.8125rem] py-2 px-4 self-start">Change password</button>
     </form>
-    <p x-show="passwordMsg()" class="text-xs text-success mt-2" x-text="passwordMsg()"></p>
-    <p x-show="passwordErr()" class="text-xs text-error mt-2" x-text="passwordErr()"></p>
+    <p x-show="passwordMsg()" class="text-xs text-success mt-2">{{ passwordMsg() }}</p>
+    <p x-show="passwordErr()" class="text-xs text-error mt-2">{{ passwordErr() }}</p>
   </div>
 
   <div class="panel mb-4">
@@ -155,8 +155,8 @@ onMount(() => {
       </div>
       <button type="submit" class="btn btn-primary text-[0.8125rem] py-2 px-4 self-start">Change email</button>
     </form>
-    <p x-show="emailMsg()" class="text-xs text-success mt-2" x-text="emailMsg()"></p>
-    <p x-show="emailErr()" class="text-xs text-error mt-2" x-text="emailErr()"></p>
+    <p x-show="emailMsg()" class="text-xs text-success mt-2">{{ emailMsg() }}</p>
+    <p x-show="emailErr()" class="text-xs text-error mt-2">{{ emailErr() }}</p>
   </div>
 
   <div class="panel">

--- a/resources/components/dashboard/BrowsersPanel.stx
+++ b/resources/components/dashboard/BrowsersPanel.stx
@@ -35,9 +35,9 @@ onMount(() => {
     </thead>
     <tbody>
       <tr x-for="browser in analytics.browsers" @loading="analytics.loading()">
-        <td class="cell-name" x-text="browser.name ? browser.name : 'Unknown'"></td>
-        <td class="cell-value" x-text="fmt(browser.visitors)"></td>
-        <td class="cell-value" x-text="(browser.percentage ? browser.percentage : 0) + '%'"></td>
+        <td class="cell-name">{{ browser.name ? browser.name : 'Unknown' }}</td>
+        <td class="cell-value">{{ fmt(browser.visitors) }}</td>
+        <td class="cell-value">{{ (browser.percentage ? browser.percentage : 0) + '%' }}</td>
       </tr>
       <tr @for-loading>
         <td colspan="3" class="text-center text-muted py-4">Loading...</td>

--- a/resources/components/dashboard/CampaignsPanel.stx
+++ b/resources/components/dashboard/CampaignsPanel.stx
@@ -53,9 +53,9 @@ onMount(() => {
     </thead>
     <tbody>
       <tr x-for="campaign in campaigns" @loading="loading()">
-        <td class="cell-name" x-text="campaign.name ? campaign.name : (campaign.source ? campaign.source : 'Unknown')"></td>
-        <td class="cell-value" x-text="fmt(campaign.visitors ? campaign.visitors : 0)"></td>
-        <td class="cell-value" x-text="fmt(campaign.views ? campaign.views : 0)"></td>
+        <td class="cell-name">{{ campaign.name ? campaign.name : (campaign.source ? campaign.source : 'Unknown') }}</td>
+        <td class="cell-value">{{ fmt(campaign.visitors ? campaign.visitors : 0) }}</td>
+        <td class="cell-value">{{ fmt(campaign.views ? campaign.views : 0) }}</td>
       </tr>
       <tr @for-loading>
         <td colspan="3" class="text-center text-muted py-4">Loading...</td>

--- a/resources/components/dashboard/ChannelsPanel.stx
+++ b/resources/components/dashboard/ChannelsPanel.stx
@@ -62,13 +62,13 @@ effect(() => {
   <div class="flex flex-col gap-3">
     <div x-for="ch in channels" @loading="loading()" class="flex flex-col gap-1">
       <div class="flex justify-between items-center">
-        <span class="text-[0.8125rem] text-text font-medium" x-text="ch.channel"></span>
-        <span class="text-xs text-muted shrink-0 ml-2" x-text="pct(ch.visitors ? ch.visitors : 0) + '%'"></span>
+        <span class="text-[0.8125rem] text-text font-medium">{{ ch.channel }}</span>
+        <span class="text-xs text-muted shrink-0 ml-2">{{ pct(ch.visitors ? ch.visitors : 0) + '%' }}</span>
       </div>
       <div class="h-1.5 bg-bg-3 rounded-sm overflow-hidden">
         <div class="h-full bg-accent rounded-sm transition-[width] duration-300" x-style="'width: ' + pct(ch.visitors ? ch.visitors : 0) + '%'"></div>
       </div>
-      <div class="text-[0.6875rem] text-muted text-right" x-text="fmtNum(ch.visitors) + ' visitors'"></div>
+      <div class="text-[0.6875rem] text-muted text-right">{{ fmtNum(ch.visitors) + ' visitors' }}</div>
     </div>
     <div @for-loading class="text-center text-muted py-4 text-[0.8125rem]">Loading...</div>
     <div @for-empty class="text-center text-muted py-4 text-[0.8125rem]">No channel data</div>

--- a/resources/components/dashboard/ControlsBar.stx
+++ b/resources/components/dashboard/ControlsBar.stx
@@ -116,7 +116,7 @@ provide('controlsBar', {
 
 <div id="controls-bar" class="flex justify-between items-center py-3 px-6 bg-bg border-b border-border gap-4 flex-wrap max-sm:flex-col max-sm:items-stretch" x-show="dashboard.controlsVisible()">
   <div class="flex items-center gap-1 max-sm:justify-center">
-    <button x-for="range in ranges" x-class="rangeBtnClass(range)" @click="setRange(range.id)" x-text="range.label"></button>
+    <button x-for="range in ranges" x-class="rangeBtnClass(range)" @click="setRange(range.id)">{{ range.label }}</button>
     <span class="border-l border-border h-6 mx-2"></span>
     <button id="compare-btn" x-class="compareBtnClass()" @click="toggleComparison()" title="Compare with previous period">
       <Icon name="bar-chart-2" size="14" />
@@ -126,9 +126,9 @@ provide('controlsBar', {
   <div class="flex items-center gap-3 max-sm:justify-between">
     <div class="realtime-badge flex items-center gap-2 py-1.5 px-3 rounded-full text-xs font-medium text-success">
       <span class="pulse"></span>
-      <span id="realtime-count" x-text="realtimeLabel()"></span>
+      <span id="realtime-count">{{ realtimeLabel() }}</span>
     </div>
-    <span id="last-updated" class="text-xs text-muted" x-show="lastUpdated()" x-text="lastUpdated()"></span>
+    <span id="last-updated" class="text-xs text-muted" x-show="lastUpdated()">{{ lastUpdated() }}</span>
     <button id="refresh-btn" x-class="refreshBtnClass()" @click="refresh()" title="Refresh data">
       <Icon name="refresh-cw" size="16" />
     </button>

--- a/resources/components/dashboard/CountriesPanel.stx
+++ b/resources/components/dashboard/CountriesPanel.stx
@@ -52,10 +52,10 @@ onMount(() => {
     <tbody>
       <tr x-for="country in analytics.countries" @loading="analytics.loading()">
         <td class="cell-name flex items-center gap-1.5">
-          <span class="text-base" x-text="getFlag(country.name ? country.name : country.code)"></span>
-          <span x-text="country.name ? country.name : (country.code ? country.code : 'Unknown')"></span>
+          <span class="text-base">{{ getFlag(country.name ? country.name : country.code) }}</span>
+          <span>{{ country.name ? country.name : (country.code ? country.code : 'Unknown') }}</span>
         </td>
-        <td class="cell-value" x-text="fmt(country.visitors)"></td>
+        <td class="cell-value">{{ fmt(country.visitors) }}</td>
       </tr>
       <tr @for-loading>
         <td colspan="2" class="text-center text-muted py-4">Loading...</td>

--- a/resources/components/dashboard/DashboardHeader.stx
+++ b/resources/components/dashboard/DashboardHeader.stx
@@ -156,7 +156,7 @@ provide('dashboardHeader', {
     <button class="icon-btn" @click="handleBack()" title="Back to sites">
       <Icon name="chevron-left" size="20" />
     </button>
-    <span id="current-site-name" class="font-semibold text-base text-text" x-text="siteName()"></span>
+    <span id="current-site-name" class="font-semibold text-base text-text">{{ siteName() }}</span>
   </div>
 
   <nav id="header-nav" class="header-nav flex gap-1 flex-wrap justify-center">
@@ -165,7 +165,7 @@ provide('dashboardHeader', {
        x-href="tabHref(tab)"
        x-data-tab="tab.id"
        data-stx-prefetch
-       x-text="tab.label"></a>
+>{{ tab.label }}</a>
   </nav>
 
   <div class="flex items-center gap-2">
@@ -181,7 +181,7 @@ provide('dashboardHeader', {
     </button>
     <a x-href="'/dashboard/account' + (siteId() ? '?siteId=' + encodeURIComponent(siteId()) : '')" x-show="userEmail()" class="flex items-center gap-1.5 icon-btn no-underline" title="Account settings" data-stx-prefetch>
       <Icon name="user" size="18" />
-      <span class="text-xs text-muted max-w-[160px] truncate hidden md:inline" x-text="userEmail()"></span>
+      <span class="text-xs text-muted max-w-[160px] truncate hidden md:inline">{{ userEmail() }}</span>
     </a>
     <form method="POST" action="/logout" class="inline">
       <button type="submit" class="icon-btn hover:text-error" title="Logout">

--- a/resources/components/dashboard/DevicesPanel.stx
+++ b/resources/components/dashboard/DevicesPanel.stx
@@ -54,10 +54,10 @@ onMount(() => {
           <svg class="text-muted shrink-0" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="getIconPath(device.type)"/>
           </svg>
-          <span x-text="capitalize(device.type ? device.type : 'Unknown')"></span>
+          <span>{{ capitalize(device.type ? device.type : 'Unknown') }}</span>
         </td>
-        <td class="cell-value" x-text="fmt(device.visitors)"></td>
-        <td class="cell-value" x-text="(device.percentage ? device.percentage : 0) + '%'"></td>
+        <td class="cell-value">{{ fmt(device.visitors) }}</td>
+        <td class="cell-value">{{ (device.percentage ? device.percentage : 0) + '%' }}</td>
       </tr>
       <tr @for-loading>
         <td colspan="3" class="text-center text-muted py-4">Loading...</td>

--- a/resources/components/dashboard/EngagementPanel.stx
+++ b/resources/components/dashboard/EngagementPanel.stx
@@ -61,11 +61,11 @@ effect(() => {
   <div class="flex gap-8 mb-4">
     <div class="flex flex-col">
       <span class="text-[0.6875rem] uppercase tracking-wide text-muted">Avg. time on page</span>
-      <span class="text-lg font-semibold text-text" x-text="fmtTime(avgSeconds())"></span>
+      <span class="text-lg font-semibold text-text">{{ fmtTime(avgSeconds()) }}</span>
     </div>
     <div class="flex flex-col">
       <span class="text-[0.6875rem] uppercase tracking-wide text-muted">Avg. scroll depth</span>
-      <span class="text-lg font-semibold text-text" x-text="avgScroll() + '%'"></span>
+      <span class="text-lg font-semibold text-text">{{ avgScroll() + '%' }}</span>
     </div>
   </div>
 
@@ -79,9 +79,9 @@ effect(() => {
     </thead>
     <tbody>
       <tr x-for="p in pages" @loading="loading()">
-        <td class="cell-name truncate" x-text="p.path"></td>
-        <td class="cell-value" x-text="fmtTime(p.avgSeconds)"></td>
-        <td class="cell-value" x-text="p.avgScrollDepth + '%'"></td>
+        <td class="cell-name truncate">{{ p.path }}</td>
+        <td class="cell-value">{{ fmtTime(p.avgSeconds) }}</td>
+        <td class="cell-value">{{ p.avgScrollDepth + '%' }}</td>
       </tr>
       <tr @for-loading>
         <td colspan="3" class="text-center text-muted py-4">Loading...</td>

--- a/resources/components/dashboard/ErrorDetail.stx
+++ b/resources/components/dashboard/ErrorDetail.stx
@@ -83,16 +83,16 @@ finally {
   </a>
 
   <div x-show="loading()" class="text-center text-muted py-12">Loading issue…</div>
-  <div x-show="!loading() && loadError()" class="text-center text-error py-12" x-text="loadError()"></div>
+  <div x-show="!loading() && loadError()" class="text-center text-error py-12">{{ loadError() }}</div>
 
   <div x-show="!loading() && !loadError()">
     <!-- Header -->
     <div class="flex items-start justify-between gap-4 mb-4">
-      <h1 class="text-lg font-semibold text-text break-words" x-text="issue().message"></h1>
+      <h1 class="text-lg font-semibold text-text break-words">{{ issue().message }}</h1>
       <div class="flex gap-2 shrink-0">
-        <span class="text-[0.625rem] font-semibold py-0.5 px-2 rounded uppercase tracking-wide border" x-class="statusColor()" x-text="statusLabel()"></span>
-        <span class="text-[0.625rem] font-semibold py-0.5 px-2 rounded uppercase tracking-wide border border-border text-text-2" x-text="severityLabel()"></span>
-        <span x-show="issue().status === 'open' && issue().trend" class="text-[0.625rem] font-semibold py-0.5 px-2 rounded uppercase tracking-wide border border-border text-text-2" x-text="issue().trend"></span>
+        <span class="text-[0.625rem] font-semibold py-0.5 px-2 rounded uppercase tracking-wide border" x-class="statusColor()">{{ statusLabel() }}</span>
+        <span class="text-[0.625rem] font-semibold py-0.5 px-2 rounded uppercase tracking-wide border border-border text-text-2">{{ severityLabel() }}</span>
+        <span x-show="issue().status === 'open' && issue().trend" class="text-[0.625rem] font-semibold py-0.5 px-2 rounded uppercase tracking-wide border border-border text-text-2">{{ issue().trend }}</span>
       </div>
     </div>
 
@@ -100,19 +100,19 @@ finally {
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
       <div class="panel py-3">
         <div class="text-xs text-muted">Events</div>
-        <div class="text-base font-semibold text-text" x-text="fmtNum(issue().count)"></div>
+        <div class="text-base font-semibold text-text">{{ fmtNum(issue().count) }}</div>
       </div>
       <div class="panel py-3">
         <div class="text-xs text-muted">Affected</div>
-        <div class="text-base font-semibold text-text" x-text="fmtNum(issue().affectedVisitors)"></div>
+        <div class="text-base font-semibold text-text">{{ fmtNum(issue().affectedVisitors) }}</div>
       </div>
       <div class="panel py-3">
         <div class="text-xs text-muted">First seen</div>
-        <div class="text-[0.8125rem] font-medium text-text" x-text="when(issue().firstSeen)"></div>
+        <div class="text-[0.8125rem] font-medium text-text">{{ when(issue().firstSeen) }}</div>
       </div>
       <div class="panel py-3">
         <div class="text-xs text-muted">Last seen</div>
-        <div class="text-[0.8125rem] font-medium text-text" x-text="when(issue().lastSeen)"></div>
+        <div class="text-[0.8125rem] font-medium text-text">{{ when(issue().lastSeen) }}</div>
       </div>
     </div>
 
@@ -122,10 +122,10 @@ finally {
         <div class="panel-title m-0">Stack trace</div>
         <span x-show="latest().symbolicatedStack" class="text-[0.625rem] font-semibold py-0.5 px-[7px] rounded uppercase tracking-wide border border-success text-success">Symbolicated</span>
       </div>
-      <pre class="text-xs text-text-2 overflow-x-auto whitespace-pre-wrap break-words bg-bg-3 rounded-md p-3 m-0" x-text="latest().symbolicatedStack || latest().stack || 'No stack trace captured'"></pre>
+      <pre class="text-xs text-text-2 overflow-x-auto whitespace-pre-wrap break-words bg-bg-3 rounded-md p-3 m-0">{{ latest().symbolicatedStack || latest().stack || 'No stack trace captured' }}</pre>
       <details x-show="latest().symbolicatedStack" class="mt-2">
         <summary class="text-[0.6875rem] text-muted cursor-pointer">Show raw (minified) stack</summary>
-        <pre class="text-xs text-text-2 overflow-x-auto whitespace-pre-wrap break-words bg-bg-3 rounded-md p-3 mt-2 mb-0" x-text="latest().stack"></pre>
+        <pre class="text-xs text-text-2 overflow-x-auto whitespace-pre-wrap break-words bg-bg-3 rounded-md p-3 mt-2 mb-0">{{ latest().stack }}</pre>
       </details>
     </div>
 
@@ -134,8 +134,8 @@ finally {
       <div class="panel-title mb-2">Breadcrumbs</div>
       <div class="flex flex-col gap-1">
         <div x-for="c in breadcrumbs" class="flex items-center gap-2 text-xs border-b border-bg-3 py-1.5 last:border-0">
-          <span class="text-muted font-mono shrink-0 w-28 truncate" x-text="c.category || 'log'"></span>
-          <span class="text-text-2 truncate" x-text="c.message || ''"></span>
+          <span class="text-muted font-mono shrink-0 w-28 truncate">{{ c.category || 'log' }}</span>
+          <span class="text-text-2 truncate">{{ c.message || '' }}</span>
         </div>
       </div>
     </div>
@@ -154,10 +154,10 @@ finally {
         </thead>
         <tbody>
           <tr x-for="o in occurrences" class="border-b border-bg-3">
-            <td class="py-1.5 text-text-2 whitespace-nowrap" x-text="when(o.timestamp)"></td>
-            <td class="py-1.5 text-text-2" x-text="o.browser || '—'"></td>
-            <td class="py-1.5 text-text-2" x-text="o.os || '—'"></td>
-            <td class="py-1.5 text-text-2 truncate max-w-[24rem]" x-text="o.url || '—'"></td>
+            <td class="py-1.5 text-text-2 whitespace-nowrap">{{ when(o.timestamp) }}</td>
+            <td class="py-1.5 text-text-2">{{ o.browser || '—' }}</td>
+            <td class="py-1.5 text-text-2">{{ o.os || '—' }}</td>
+            <td class="py-1.5 text-text-2 truncate max-w-[24rem]">{{ o.url || '—' }}</td>
           </tr>
         </tbody>
       </table>
@@ -167,7 +167,7 @@ finally {
     <div x-show="browsers().length > 0" class="panel">
       <div class="panel-title mb-2">Affected browsers</div>
       <div class="flex flex-wrap gap-2">
-        <span x-for="b in browsers" class="text-xs text-text-2 border border-border rounded px-2 py-0.5" x-text="b"></span>
+        <span x-for="b in browsers" class="text-xs text-text-2 border border-border rounded px-2 py-0.5">{{ b }}</span>
       </div>
     </div>
   </div>

--- a/resources/components/dashboard/EventPropertiesPanel.stx
+++ b/resources/components/dashboard/EventPropertiesPanel.stx
@@ -74,21 +74,21 @@ effect(() => {
 
   <div x-show="eventChips().length > 0" class="flex flex-wrap gap-2 mb-3">
     <span x-for="chip in eventChips" class="inline-flex items-center gap-1 rounded-full bg-bg-3 px-2 py-0.5 text-[0.6875rem] text-muted">
-      <span x-text="chip.name"></span>
-      <span class="font-medium text-text" x-text="fmtNum(chip.count)"></span>
+      <span>{{ chip.name }}</span>
+      <span class="font-medium text-text">{{ fmtNum(chip.count) }}</span>
     </span>
   </div>
 
   <div class="flex flex-col gap-3">
     <div x-for="r in rows" @loading="loading()" class="flex flex-col gap-1">
       <div class="flex justify-between items-center gap-2">
-        <span class="text-[0.8125rem] text-text font-medium truncate" x-text="rowLabel(r)"></span>
-        <span class="text-xs text-muted shrink-0 ml-2" x-text="fmtNum(r.count)"></span>
+        <span class="text-[0.8125rem] text-text font-medium truncate">{{ rowLabel(r) }}</span>
+        <span class="text-xs text-muted shrink-0 ml-2">{{ fmtNum(r.count) }}</span>
       </div>
       <div class="h-1.5 bg-bg-3 rounded-sm overflow-hidden">
         <div class="h-full bg-accent rounded-sm transition-[width] duration-300" x-style="'width: ' + barWidth(r.count ? r.count : 0) + '%'"></div>
       </div>
-      <div class="text-[0.6875rem] text-muted text-right" x-text="fmtNum(r.visitors) + ' visitors'"></div>
+      <div class="text-[0.6875rem] text-muted text-right">{{ fmtNum(r.visitors) + ' visitors' }}</div>
     </div>
     <div @for-loading class="text-center text-muted py-4 text-[0.8125rem]">Loading...</div>
     <div @for-empty class="text-center text-muted py-4 text-[0.8125rem]">No event properties tracked yet</div>

--- a/resources/components/dashboard/EventsPanel.stx
+++ b/resources/components/dashboard/EventsPanel.stx
@@ -60,13 +60,13 @@ onMount(() => {
   <div class="flex flex-col gap-3">
     <div x-for="event in events" @loading="loading()" class="flex flex-col gap-1">
       <div class="flex justify-between items-center">
-        <span class="text-[0.8125rem] text-text font-medium truncate" x-text="event.name"></span>
-        <span class="text-xs text-muted shrink-0 ml-2" x-text="getPercentage(event.count ? event.count : 0) + '%'"></span>
+        <span class="text-[0.8125rem] text-text font-medium truncate">{{ event.name }}</span>
+        <span class="text-xs text-muted shrink-0 ml-2">{{ getPercentage(event.count ? event.count : 0) + '%' }}</span>
       </div>
       <div class="h-1.5 bg-bg-3 rounded-sm overflow-hidden">
         <div class="h-full bg-accent rounded-sm transition-[width] duration-300" x-style="'width: ' + getBarWidth(event.count ? event.count : 0) + '%'"></div>
       </div>
-      <div class="text-[0.6875rem] text-muted text-right" x-text="fmt(event.count)"></div>
+      <div class="text-[0.6875rem] text-muted text-right">{{ fmt(event.count) }}</div>
     </div>
     <div @for-loading class="text-center text-muted py-4 text-[0.8125rem]">Loading...</div>
     <div @for-empty class="text-center text-muted py-4 text-[0.8125rem]">No custom events tracked</div>

--- a/resources/components/dashboard/GoalModal.stx
+++ b/resources/components/dashboard/GoalModal.stx
@@ -128,10 +128,10 @@ onMount(() => {
 
 <div x-show="showModal()" class="modal-overlay" @click.self="closeModal">
   <div class="modal-content bg-bg-2 max-w-[420px] p-6">
-    <h3 class="text-lg font-semibold text-text mb-6" x-text="modalTitle()"></h3>
+    <h3 class="text-lg font-semibold text-text mb-6">{{ modalTitle() }}</h3>
 
     <form @submit="handleSubmit">
-      <div x-show="error()" class="error-message" x-text="error()"></div>
+      <div x-show="error()" class="error-message">{{ error() }}</div>
 
       <label class="block mb-4 text-[0.8125rem] text-text-2">
         Name
@@ -200,7 +200,7 @@ onMount(() => {
         <button type="button" class="btn btn-secondary" @click="closeModal" x-disabled="saving()">
           Cancel
         </button>
-        <button type="submit" class="btn btn-primary" x-disabled="saving()" x-text="saving() ? 'Saving...' : 'Save Goal'"></button>
+        <button type="submit" class="btn btn-primary" x-disabled="saving()">{{ saving() ? 'Saving...' : 'Save Goal' }}</button>
       </div>
     </form>
   </div>

--- a/resources/components/dashboard/GoalsPanel.stx
+++ b/resources/components/dashboard/GoalsPanel.stx
@@ -92,13 +92,13 @@ window.refreshGoalsPanel = loadGoals
     </thead>
     <tbody>
       <tr x-for="goal in goals" class="goal-row">
-        <td class="font-medium" x-text="goal.name"></td>
+        <td class="font-medium">{{ goal.name }}</td>
         <td>
-          <span x-class="getTypeBadgeClass(goal.type)" x-text="goal.type"></span>
+          <span x-class="getTypeBadgeClass(goal.type)">{{ goal.type }}</span>
         </td>
-        <td class="text-right tabular-nums" x-text="fmt(goal.conversions ? goal.conversions : 0)"></td>
+        <td class="text-right tabular-nums">{{ fmt(goal.conversions ? goal.conversions : 0) }}</td>
         <td class="text-right tabular-nums">
-          <span x-show="goal.value" x-text="formatCurrency(goal.value)"></span>
+          <span x-show="goal.value">{{ formatCurrency(goal.value) }}</span>
           <span x-show="!goal.value">-</span>
         </td>
         <td class="text-right whitespace-nowrap">

--- a/resources/components/dashboard/LinkClicksPanel.stx
+++ b/resources/components/dashboard/LinkClicksPanel.stx
@@ -74,21 +74,21 @@ effect(() => {
 
   <div x-show="kindChips().length > 0" class="flex flex-wrap gap-2 mb-3">
     <span x-for="chip in kindChips" class="inline-flex items-center gap-1 rounded-full bg-bg-3 px-2 py-0.5 text-[0.6875rem] text-muted">
-      <span x-text="chip.label"></span>
-      <span class="font-medium text-text" x-text="fmtNum(chip.count)"></span>
+      <span>{{ chip.label }}</span>
+      <span class="font-medium text-text">{{ fmtNum(chip.count) }}</span>
     </span>
   </div>
 
   <div class="flex flex-col gap-3">
     <div x-for="c in clicks" @loading="loading()" class="flex flex-col gap-1">
       <div class="flex justify-between items-center gap-2">
-        <span class="text-[0.8125rem] text-text font-medium truncate" x-text="clickLabel(c)"></span>
-        <span class="shrink-0 rounded-sm bg-bg-3 px-1.5 py-0.5 text-[0.625rem] uppercase tracking-wide text-muted" x-text="c.kind"></span>
+        <span class="text-[0.8125rem] text-text font-medium truncate">{{ clickLabel(c) }}</span>
+        <span class="shrink-0 rounded-sm bg-bg-3 px-1.5 py-0.5 text-[0.625rem] uppercase tracking-wide text-muted">{{ c.kind }}</span>
       </div>
       <div class="h-1.5 bg-bg-3 rounded-sm overflow-hidden">
         <div class="h-full bg-accent rounded-sm transition-[width] duration-300" x-style="'width: ' + barWidth(c.count ? c.count : 0) + '%'"></div>
       </div>
-      <div class="text-[0.6875rem] text-muted text-right" x-text="fmtNum(c.count) + ' clicks'"></div>
+      <div class="text-[0.6875rem] text-muted text-right">{{ fmtNum(c.count) + ' clicks' }}</div>
     </div>
     <div @for-loading class="text-center text-muted py-4 text-[0.8125rem]">Loading...</div>
     <div @for-empty class="text-center text-muted py-4 text-[0.8125rem]">No link clicks tracked yet</div>

--- a/resources/components/dashboard/NoDataMessage.stx
+++ b/resources/components/dashboard/NoDataMessage.stx
@@ -40,7 +40,7 @@ effect(() => {
   <Icon name="bar-chart-2" size="48" class="text-warning mb-4 mx-auto" />
   <h3 class="mb-2 text-warning">No analytics data yet</h3>
   <p class="text-text-2 mb-4">Add the tracking script to your website to start collecting data.</p>
-  <code id="tracking-script" class="block bg-bg p-4 rounded-md text-xs mt-4 text-accent-2 break-all text-left" x-text="trackingSnippet()"></code>
+  <code id="tracking-script" class="block bg-bg p-4 rounded-md text-xs mt-4 text-accent-2 break-all text-left">{{ trackingSnippet() }}</code>
   <div class="flex items-start gap-4 text-left mt-6 pt-6 border-t border-border">
     <div class="bg-accent text-white w-6 h-6 rounded-full inline-flex items-center justify-center text-xs font-semibold flex-shrink-0">1</div>
     <div class="flex-1">

--- a/resources/components/dashboard/PagesPanel.stx
+++ b/resources/components/dashboard/PagesPanel.stx
@@ -38,13 +38,13 @@ onMount(() => {
       <tr x-for="page in analytics.pages" @loading="analytics.loading()">
         <td class="cell-name" :title="page.path">
           <a x-href="page.path" target="_blank" rel="noopener" class="inline-flex items-center gap-1 hover:text-accent">
-            <span x-text="page.path"></span>
+            <span>{{ page.path }}</span>
             <Icon name="external-link" size="10" class="opacity-50" />
           </a>
         </td>
-        <td class="cell-value" x-text="fmt(page.entries)"></td>
-        <td class="cell-value" x-text="fmt(page.visitors)"></td>
-        <td class="cell-value" x-text="fmt(page.views)"></td>
+        <td class="cell-value">{{ fmt(page.entries) }}</td>
+        <td class="cell-value">{{ fmt(page.visitors) }}</td>
+        <td class="cell-value">{{ fmt(page.views) }}</td>
       </tr>
       <tr @for-loading>
         <td colspan="4" class="text-center text-muted py-4">Loading...</td>

--- a/resources/components/dashboard/ReferrersPanel.stx
+++ b/resources/components/dashboard/ReferrersPanel.stx
@@ -83,13 +83,13 @@ onMount(() => {
               class="align-middle rounded-sm"
               @error="e => e.target.style.display = 'none'"
             />
-            <span x-text="ref.source ? ref.source : 'Direct'"></span>
+            <span>{{ ref.source ? ref.source : 'Direct' }}</span>
             <Icon name="external-link" size="10" class="opacity-50" />
           </a>
-          <span x-show="!isExternalLink(ref.source ? ref.source : 'Direct')" x-text="ref.source ? ref.source : 'Direct'"></span>
+          <span x-show="!isExternalLink(ref.source ? ref.source : 'Direct')">{{ ref.source ? ref.source : 'Direct' }}</span>
         </td>
-        <td class="cell-value" x-text="fmt(ref.visitors)"></td>
-        <td class="cell-value" x-text="fmt(ref.views)"></td>
+        <td class="cell-value">{{ fmt(ref.visitors) }}</td>
+        <td class="cell-value">{{ fmt(ref.views) }}</td>
       </tr>
       <tr @for-loading>
         <td colspan="3" class="text-center text-muted py-4">Loading...</td>

--- a/resources/components/dashboard/SiteSelector.stx
+++ b/resources/components/dashboard/SiteSelector.stx
@@ -205,7 +205,7 @@ onMount(() => {
 
     <div x-show="!loading() && error()" class="site-status">
       <Icon name="alert-triangle" size="32" class="text-error" style="opacity:0.7;margin-bottom:0.75rem" />
-      <p x-text="error()"></p>
+      <p>{{ error() }}</p>
       <button class="retry-btn" @click="fetchSites()">Retry</button>
     </div>
 
@@ -219,9 +219,9 @@ onMount(() => {
           <input type="text" placeholder="Domain (optional)"
                  x-value="newDomain()" @input="newDomain.set($event.target.value)"
                  class="form-input" />
-          <button type="submit" class="create-btn" x-disabled="creating()" x-text="creating() ? 'Creating...' : 'Create'"></button>
+          <button type="submit" class="create-btn" x-disabled="creating()">{{ creating() ? 'Creating...' : 'Create' }}</button>
         </form>
-        <p x-show="createError()" class="create-error" x-text="createError()"></p>
+        <p x-show="createError()" class="create-error">{{ createError() }}</p>
       </div>
 
       <div x-show="sites().length === 0" class="site-empty">
@@ -237,8 +237,8 @@ onMount(() => {
             <Icon name="clock" size="24" />
           </div>
           <div class="site-info">
-            <span class="site-name" x-text="site.name || 'Unnamed'"></span>
-            <span class="site-domain" x-text="site.domains?.[0] || site.id"></span>
+            <span class="site-name">{{ site.name || 'Unnamed' }}</span>
+            <span class="site-domain">{{ site.domains?.[0] || site.id }}</span>
           </div>
           <Icon name="chevron-right" size="20" class="site-arrow" />
         </button>
@@ -254,12 +254,12 @@ onMount(() => {
             <Icon name="globe" size="24" />
           </div>
           <div class="site-info">
-            <span class="site-name" x-text="site.name || 'Unnamed'"></span>
-            <span class="site-domain" x-text="site.domains?.[0] || site.id"></span>
+            <span class="site-name">{{ site.name || 'Unnamed' }}</span>
+            <span class="site-domain">{{ site.domains?.[0] || site.id }}</span>
           </div>
           <Icon name="chevron-right" size="20" class="site-arrow" />
         </button>
-        <p x-show="searchQuery() && filteredSites().length === 0" class="text-xs text-muted mt-2">No projects match "<span x-text="searchQuery()"></span>"</p>
+        <p x-show="searchQuery() && filteredSites().length === 0" class="text-xs text-muted mt-2">No projects match "<span>{{ searchQuery() }}</span>"</p>
       </div>
     </div>
   </div>

--- a/resources/components/dashboard/StatsRow.stx
+++ b/resources/components/dashboard/StatsRow.stx
@@ -145,7 +145,7 @@ onMount(() => {
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="stat.icon"/>
     </svg>
     <div class="text-2xl font-bold text-text leading-tight" x-text="statValue(stat.id)">—</div>
-    <div class="text-xs text-text-2 mt-1 uppercase tracking-wide" x-text="stat.label"></div>
+    <div class="text-xs text-text-2 mt-1 uppercase tracking-wide">{{ stat.label }}</div>
   </div>
 </div>
 

--- a/resources/components/shared/DetailView.stx
+++ b/resources/components/shared/DetailView.stx
@@ -181,12 +181,12 @@ effect(() => {
       <table class="data-table w-full">
         <thead>
           <tr>
-            <th x-for="key in columnKeys" class="text-left p-3 text-muted font-medium text-sm border-b border-border" x-text="formatKey(key)"></th>
+            <th x-for="key in columnKeys" class="text-left p-3 text-muted font-medium text-sm border-b border-border">{{ formatKey(key) }}</th>
           </tr>
         </thead>
         <tbody>
           <tr x-for="item in paginatedData" class="hover:bg-bg-3">
-            <td x-for="key in columnKeys" class="p-3 text-sm border-b border-bg-3" x-text="formatValue(item[key], key)"></td>
+            <td x-for="key in columnKeys" class="p-3 text-sm border-b border-bg-3">{{ formatValue(item[key], key) }}</td>
           </tr>
         </tbody>
       </table>

--- a/resources/components/tabs/ErrorsTab.stx
+++ b/resources/components/tabs/ErrorsTab.stx
@@ -207,9 +207,7 @@ onMount(() => {
   <div class="flex gap-1 mb-4">
     <button x-for="r in dateRangeOptions"
       x-class="rangeBtnClass(r.id)"
-      @click="setErrorDateRange(r.id)"
-      x-text="r.label">
-    </button>
+      @click="setErrorDateRange(r.id)">{{ r.label }}</button>
   </div>
 
   <div x-show="loading()" class="text-center text-text-2 py-10 px-8 bg-bg-2 border border-border rounded-lg flex flex-col items-center gap-2">
@@ -231,8 +229,8 @@ onMount(() => {
   <div x-show="!loading() && !error() && errors().length > 0">
     <div class="severity-grid grid grid-cols-4 gap-2 mb-3">
       <div x-for="sev in severityKeys" x-class="sevStatClass(sev)">
-        <span class="text-lg font-bold text-text" x-text="severityCounts()[sev]"></span>
-        <span class="text-[0.6875rem] text-muted uppercase tracking-wider" x-text="severityLabels[sev]"></span>
+        <span class="text-lg font-bold text-text">{{ severityCounts()[sev] }}</span>
+        <span class="text-[0.6875rem] text-muted uppercase tracking-wider">{{ severityLabels[sev] }}</span>
       </div>
     </div>
 
@@ -275,24 +273,24 @@ onMount(() => {
           <div class="flex-1 min-w-0 py-3 px-4 flex flex-col gap-1.5">
             <div class="flex items-center justify-between gap-2">
               <div class="flex gap-1.5 items-center flex-wrap">
-                <span x-class="badgeSeverityClass(e)" x-text="severityLabels[e.severity] || 'Unknown'"></span>
-                <span class="text-[0.625rem] font-semibold py-0.5 px-[7px] rounded uppercase tracking-wide whitespace-nowrap bg-bg-3 text-text-2" x-text="e.category || 'Error'"></span>
-                <span x-class="badgeStatusClass(e)" x-text="statusLabels[getErrorStatus(e.fingerprint)] || 'New'"></span>
+                <span x-class="badgeSeverityClass(e)">{{ severityLabels[e.severity] || 'Unknown' }}</span>
+                <span class="text-[0.625rem] font-semibold py-0.5 px-[7px] rounded uppercase tracking-wide whitespace-nowrap bg-bg-3 text-text-2">{{ e.category || 'Error' }}</span>
+                <span x-class="badgeStatusClass(e)">{{ statusLabels[getErrorStatus(e.fingerprint)] || 'New' }}</span>
                 <span x-show="isRegressed(e.fingerprint)" class="text-[0.625rem] font-semibold py-0.5 px-[7px] rounded uppercase tracking-wide whitespace-nowrap border border-error text-error">Regressed</span>
               </div>
               <span class="inline-flex items-center gap-1 text-[0.6875rem] font-semibold text-text-2 whitespace-nowrap">
                 <Icon name="zap" size="12" class="text-muted" />
-                <span x-text="e.count"></span>
+                <span>{{ e.count }}</span>
               </span>
             </div>
-            <div class="text-[0.8125rem] text-text leading-relaxed overflow-hidden text-ellipsis line-clamp-2 break-words" x-text="e.message || 'Unknown error'"></div>
+            <div class="text-[0.8125rem] text-text leading-relaxed overflow-hidden text-ellipsis line-clamp-2 break-words">{{ e.message || 'Unknown error' }}</div>
             <div class="flex gap-3 items-center flex-wrap">
               <span class="inline-flex items-center gap-1 text-[0.6875rem] text-muted">
                 <Icon name="clock" size="11" class="opacity-60" />
-                <span x-text="timeAgo(e.lastSeen)"></span>
+                <span>{{ timeAgo(e.lastSeen) }}</span>
               </span>
-              <span x-show="e.source" class="inline-flex items-center gap-1 text-[0.6875rem] text-muted font-mono text-text-2" x-text="e.source.split('/').pop() + (e.line ? ':' + e.line : '')"></span>
-              <span class="inline-flex items-center gap-1 text-[0.6875rem] text-muted" x-text="(e.browsers || []).join(', ') || 'server'"></span>
+              <span x-show="e.source" class="inline-flex items-center gap-1 text-[0.6875rem] text-muted font-mono text-text-2">{{ e.source.split('/').pop() + (e.line ? ':' + e.line : '') }}</span>
+              <span class="inline-flex items-center gap-1 text-[0.6875rem] text-muted">{{ (e.browsers || []).join(', ') || 'server' }}</span>
             </div>
           </div>
           <div class="error-actions flex flex-col gap-0.5 py-2 px-2 opacity-0 transition-opacity duration-150 items-center justify-center group-hover:opacity-100" @click.stop>

--- a/resources/components/tabs/FlowTab.stx
+++ b/resources/components/tabs/FlowTab.stx
@@ -61,8 +61,8 @@ onMount(() => {
         <h4 class="text-[0.6875rem] uppercase text-muted mb-3 font-medium tracking-wider">Entry Pages</h4>
         <div class="flex flex-col gap-2">
           <div x-for="page in entryPages" class="bg-bg border border-border py-2 px-3 rounded-md">
-            <div class="text-[0.8125rem] text-text truncate" x-text="page.path"></div>
-            <div class="text-[0.6875rem] text-muted" x-text="page.count + ' session' + (page.count !== 1 ? 's' : '')"></div>
+            <div class="text-[0.8125rem] text-text truncate">{{ page.path }}</div>
+            <div class="text-[0.6875rem] text-muted">{{ page.count + ' session' + (page.count !== 1 ? 's' : '') }}</div>
           </div>
         </div>
       </div>
@@ -71,10 +71,10 @@ onMount(() => {
         <h4 class="text-[0.6875rem] uppercase text-muted mb-3 font-medium tracking-wider">Top Flows</h4>
         <div class="flex flex-col gap-2">
           <div x-for="flow in topFlows" class="flex items-center gap-2 text-xs">
-            <span class="bg-bg py-1 px-2 rounded truncate max-w-[120px] text-text" x-text="flow.source"></span>
+            <span class="bg-bg py-1 px-2 rounded truncate max-w-[120px] text-text">{{ flow.source }}</span>
             <span class="text-accent">→</span>
-            <span class="bg-bg py-1 px-2 rounded truncate max-w-[120px] text-text" x-text="flow.target"></span>
-            <span class="text-muted ml-auto" x-text="flow.count"></span>
+            <span class="bg-bg py-1 px-2 rounded truncate max-w-[120px] text-text">{{ flow.target }}</span>
+            <span class="text-muted ml-auto">{{ flow.count }}</span>
           </div>
         </div>
       </div>
@@ -83,9 +83,9 @@ onMount(() => {
         <h4 class="text-[0.6875rem] uppercase text-muted mb-3 font-medium tracking-wider">Most Visited</h4>
         <div class="flex flex-col gap-2">
           <div x-for="(page, index) in mostVisited" class="flex items-center gap-2">
-            <span class="w-[18px] h-[18px] bg-accent text-white rounded-full text-[0.6875rem] flex items-center justify-center shrink-0" x-text="index + 1"></span>
-            <span class="text-xs truncate flex-1 text-text" x-text="page.path"></span>
-            <span class="text-[0.6875rem] text-muted" x-text="page.count"></span>
+            <span class="w-[18px] h-[18px] bg-accent text-white rounded-full text-[0.6875rem] flex items-center justify-center shrink-0">{{ index + 1 }}</span>
+            <span class="text-xs truncate flex-1 text-text">{{ page.path }}</span>
+            <span class="text-[0.6875rem] text-muted">{{ page.count }}</span>
           </div>
         </div>
       </div>

--- a/resources/components/tabs/FunnelsTab.stx
+++ b/resources/components/tabs/FunnelsTab.stx
@@ -193,11 +193,11 @@ onMount(() => {
       <div x-for="(step, index) in (currentAnalysis?.steps || [])" class="analysis-step-wrapper flex items-center gap-2 flex-1 min-w-[120px]">
         <div class="flex-1 text-center">
           <div class="bg-bg-2 border border-border rounded-lg p-4 mb-2">
-            <div class="text-2xl font-semibold text-text" x-text="step.visitors"></div>
-            <div class="text-[0.6875rem] text-muted mt-1"><span x-text="step.rate"></span>%</div>
+            <div class="text-2xl font-semibold text-text">{{ step.visitors }}</div>
+            <div class="text-[0.6875rem] text-muted mt-1"><span>{{ step.rate }}</span>%</div>
           </div>
-          <div class="text-xs font-medium text-text" x-text="step.path"></div>
-          <div x-show="step.dropoff > 0" class="text-[0.6875rem] text-error mt-1"><span x-text="'-' + step.dropoff + ' dropped'"></span></div>
+          <div class="text-xs font-medium text-text">{{ step.path }}</div>
+          <div x-show="step.dropoff > 0" class="text-[0.6875rem] text-error mt-1"><span>{{ '-' + step.dropoff + ' dropped' }}</span></div>
         </div>
         <div x-show="index < currentAnalysis().steps.length - 1" class="text-muted text-2xl">&rarr;</div>
       </div>
@@ -217,7 +217,7 @@ onMount(() => {
 
     <div x-for="funnel in funnels" class="bg-bg-2 border border-border rounded-lg p-4 mb-3">
       <div class="flex justify-between items-center mb-3">
-        <h4 class="text-sm font-semibold text-text m-0" x-text="funnel.name"></h4>
+        <h4 class="text-sm font-semibold text-text m-0">{{ funnel.name }}</h4>
         <div class="flex gap-1">
           <button class="icon-btn" @click="analyzeFunnel(funnel.id)" title="View analysis">
             <Icon name="bar-chart-2" size="16" />
@@ -229,7 +229,7 @@ onMount(() => {
       </div>
       <div class="flex gap-2 flex-wrap items-center">
         <span x-for="(step, idx) in funnel.steps" class="text-[0.6875rem] py-1 px-2 bg-bg rounded text-text">
-          <span x-text="step"></span>
+          <span>{{ step }}</span>
           <span x-show="idx < funnel.steps.length - 1" class="text-accent">&rarr;</span>
         </span>
       </div>

--- a/resources/components/tabs/InsightsTab.stx
+++ b/resources/components/tabs/InsightsTab.stx
@@ -101,8 +101,8 @@ onMount(() => {
           </svg>
         </div>
         <div class="flex-1 min-w-0">
-          <div class="text-sm font-semibold text-text mb-1" x-text="insight.title"></div>
-          <div class="text-[0.8125rem] text-muted leading-normal" x-text="insight.description"></div>
+          <div class="text-sm font-semibold text-text mb-1">{{ insight.title }}</div>
+          <div class="text-[0.8125rem] text-muted leading-normal">{{ insight.description }}</div>
         </div>
       </div>
     </div>

--- a/resources/components/tabs/LiveTab.stx
+++ b/resources/components/tabs/LiveTab.stx
@@ -56,12 +56,12 @@ onMount(() => {
     <div x-for="activity in activities" @loading="loading()" class="panel flex items-center gap-4 py-3 px-4">
       <div class="w-2 h-2 bg-success rounded-full flex-shrink-0"></div>
       <div class="flex-1 min-w-0">
-        <div class="text-sm text-text truncate" x-text="activity.path ? activity.path : '/'"></div>
+        <div class="text-sm text-text truncate">{{ activity.path ? activity.path : '/' }}</div>
         <div class="text-[0.6875rem] text-muted">
-          <span x-text="(activity.country ? activity.country : 'Unknown') + ' • ' + (activity.device ? activity.device : 'Unknown') + ' • ' + (activity.browser ? activity.browser : 'Unknown')"></span>
+          <span>{{ (activity.country ? activity.country : 'Unknown') + ' • ' + (activity.device ? activity.device : 'Unknown') + ' • ' + (activity.browser ? activity.browser : 'Unknown') }}</span>
         </div>
       </div>
-      <div class="text-[0.6875rem] text-muted whitespace-nowrap" x-text="timeAgo(activity.timestamp)"></div>
+      <div class="text-[0.6875rem] text-muted whitespace-nowrap">{{ timeAgo(activity.timestamp) }}</div>
     </div>
     <div @for-loading class="panel flex items-center justify-center gap-2 text-muted">
       <Spinner size="sm" color="primary" />

--- a/resources/components/tabs/SessionsTab.stx
+++ b/resources/components/tabs/SessionsTab.stx
@@ -140,14 +140,14 @@ onMount(() => {
     <div x-show="!loading() && !error() && sessions().length === 0" class="empty-state">No sessions recorded yet.</div>
     <div x-for="session in sessions" class="session-card" @click="viewSession(session.sessionId || session.id)">
       <div class="flex justify-between items-center mb-2">
-        <span class="font-medium text-text" x-text="session.entryPage || session.entryPath || '/'"></span>
-        <span class="text-xs text-muted" x-text="timeAgo(session.startTime || session.startedAt)"></span>
+        <span class="font-medium text-text">{{ session.entryPage || session.entryPath || '/' }}</span>
+        <span class="text-xs text-muted">{{ timeAgo(session.startTime || session.startedAt) }}</span>
       </div>
       <div class="flex gap-4 text-xs text-muted">
-        <span x-text="(session.pageViews || session.pageViewCount || 1) + ' page' + ((session.pageViews || session.pageViewCount || 1) !== 1 ? 's' : '')"></span>
-        <span x-class="bouncedClass(session)" x-text="(session.bounced || session.isBounce) ? 'Bounced' : formatDuration(session.duration)"></span>
-        <span x-text="session.browser || 'Unknown'"></span>
-        <span x-text="session.country || 'Unknown'"></span>
+        <span>{{ (session.pageViews || session.pageViewCount || 1) + ' page' + ((session.pageViews || session.pageViewCount || 1) !== 1 ? 's' : '') }}</span>
+        <span x-class="bouncedClass(session)">{{ (session.bounced || session.isBounce) ? 'Bounced' : formatDuration(session.duration) }}</span>
+        <span>{{ session.browser || 'Unknown' }}</span>
+        <span>{{ session.country || 'Unknown' }}</span>
       </div>
     </div>
   </div>

--- a/resources/components/tabs/SettingsTab.stx
+++ b/resources/components/tabs/SettingsTab.stx
@@ -542,7 +542,7 @@ onMount(() => {
         </button>
       </div>
     </div>
-    <p class="text-xs text-muted mb-2">Paste this one line into the <code class="text-text">&lt;head&gt;</code> of every page you want to track (site <code class="text-text" x-text="siteId()"></code>). No cookies, no consent banner needed — visitors are never personally identified.</p>
+    <p class="text-xs text-muted mb-2">Paste this one line into the <code class="text-text">&lt;head&gt;</code> of every page you want to track (site <code class="text-text">{{ siteId() }}</code>). No cookies, no consent banner needed — visitors are never personally identified.</p>
     <div class="flex flex-wrap gap-1.5 mb-3">
       <span class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-bg border border-border text-muted">Page views</span>
       <span class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-bg border border-border text-muted">SPA route changes</span>
@@ -551,7 +551,7 @@ onMount(() => {
       <span class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-bg border border-border text-muted">Web vitals</span>
       <span class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-bg border border-border text-muted">JS errors</span>
     </div>
-    <pre class="bg-bg border border-border rounded-md p-3 text-[0.75rem] text-text overflow-x-auto whitespace-pre-wrap break-all font-mono leading-relaxed" x-text="installSnippet()"></pre>
+    <pre class="bg-bg border border-border rounded-md p-3 text-[0.75rem] text-text overflow-x-auto whitespace-pre-wrap break-all font-mono leading-relaxed">{{ installSnippet() }}</pre>
     <p x-show="!installSnippet()" class="text-xs text-muted italic mt-2">Loading snippet…</p>
     <p x-show="verifyResult() === 'pass'" class="text-xs text-success mt-2">Test event received — ingestion is working end to end.</p>
     <p x-show="verifyResult() === 'fail'" class="text-xs text-error mt-2">No event received. Check that the API is reachable from your browser, then try again.</p>
@@ -564,7 +564,7 @@ onMount(() => {
         </button>
       </div>
       <p class="text-xs text-muted mb-2">Sends beacons to a short, unlisted path that generic blocklists miss. For full resilience, serve it from your own domain — see the <a class="text-primary underline" href="https://github.com/stacksjs/ts-analytics/blob/main/docs/guide/tracking-script.md#ad-blocker-resilience-first-party-proxy" target="_blank" rel="noopener">first-party proxy guide</a>.</p>
-      <pre class="bg-bg border border-border rounded-md p-3 text-[0.75rem] text-text overflow-x-auto whitespace-pre-wrap break-all font-mono leading-relaxed" x-text="stealthSnippet()"></pre>
+      <pre class="bg-bg border border-border rounded-md p-3 text-[0.75rem] text-text overflow-x-auto whitespace-pre-wrap break-all font-mono leading-relaxed">{{ stealthSnippet() }}</pre>
     </div>
   </div>
 
@@ -580,17 +580,17 @@ onMount(() => {
           <span x-show="!sdkCopied()">Copy snippet</span>
           <span x-show="sdkCopied()" class="text-success">Copied!</span>
         </button>
-        <button class="btn btn-secondary text-[0.6875rem] py-1 px-2 hover:text-error" @click="regenerateDsn()" x-disabled="regeneratingDsn()" x-text="regeneratingDsn() ? 'Regenerating…' : 'Regenerate key'"></button>
+        <button class="btn btn-secondary text-[0.6875rem] py-1 px-2 hover:text-error" @click="regenerateDsn()" x-disabled="regeneratingDsn()">{{ regeneratingDsn() ? 'Regenerating…' : 'Regenerate key' }}</button>
       </div>
     </div>
     <p class="text-xs text-muted mb-3">The analytics snippet above already reports uncaught errors. Use this DSN with the standalone SDK when you want error tracking without analytics, or richer capture (breadcrumbs, releases, <code class="text-text">captureException</code>) in your app code.</p>
     <div class="mb-3">
       <label class="text-xs font-medium text-muted mb-1 block">DSN</label>
-      <code class="block bg-bg border border-border rounded-md p-3 text-[0.75rem] text-text break-all font-mono" x-text="dsn()"></code>
+      <code class="block bg-bg border border-border rounded-md p-3 text-[0.75rem] text-text break-all font-mono">{{ dsn() }}</code>
     </div>
     <div>
       <label class="text-xs font-medium text-muted mb-1 block">SDK snippet</label>
-      <pre class="bg-bg border border-border rounded-md p-3 text-[0.75rem] text-text overflow-x-auto whitespace-pre-wrap break-all font-mono leading-relaxed" x-text="sdkSnippet()"></pre>
+      <pre class="bg-bg border border-border rounded-md p-3 text-[0.75rem] text-text overflow-x-auto whitespace-pre-wrap break-all font-mono leading-relaxed">{{ sdkSnippet() }}</pre>
     </div>
     <p x-show="!dsn()" class="text-xs text-muted italic mt-2">Loading DSN…</p>
   </div>
@@ -619,8 +619,8 @@ onMount(() => {
         <div class="flex flex-col gap-2">
           <div x-show="settings().apiKey" class="flex justify-between items-center p-2 bg-bg rounded">
             <div class="flex-1 min-w-0">
-              <div class="text-[0.8125rem] font-medium text-text" x-text="settings().apiKey ? settings().apiKey.name : ''"></div>
-              <code class="text-[0.6875rem] text-muted break-all" x-text="settings().apiKey ? settings().apiKey.key : ''"></code>
+              <div class="text-[0.8125rem] font-medium text-text">{{ settings().apiKey ? settings().apiKey.name : '' }}</div>
+              <code class="text-[0.6875rem] text-muted break-all">{{ settings().apiKey ? settings().apiKey.key : '' }}</code>
             </div>
             <div class="flex items-center gap-1">
               <button class="icon-btn" @click="copyApiKey()" title="Copy key">
@@ -643,8 +643,8 @@ onMount(() => {
           <p x-show="settings().alerts.length === 0" class="text-xs text-muted italic">No alerts configured.</p>
           <div x-for="alert in settings.alerts" class="flex justify-between items-center p-2 bg-bg rounded">
             <div class="flex-1 min-w-0">
-              <div class="text-[0.8125rem] font-medium text-text" x-text="alert.metric"></div>
-              <div class="text-[0.6875rem] text-muted" x-text="'Threshold: ' + alert.threshold + ' → ' + alert.email"></div>
+              <div class="text-[0.8125rem] font-medium text-text">{{ alert.metric }}</div>
+              <div class="text-[0.6875rem] text-muted">{{ 'Threshold: ' + alert.threshold + ' → ' + alert.email }}</div>
             </div>
             <button class="icon-btn hover:bg-error/15 hover:text-error" @click="deleteAlert(alert.id)" title="Delete">×</button>
           </div>
@@ -661,8 +661,8 @@ onMount(() => {
           <p x-show="settings().emailReports.length === 0" class="text-xs text-muted italic">No email reports scheduled.</p>
           <div x-for="report in settings.emailReports" class="flex justify-between items-center p-2 bg-bg rounded">
             <div class="flex-1 min-w-0">
-              <div class="text-[0.8125rem] font-medium text-text" x-text="report.email"></div>
-              <div class="text-[0.6875rem] text-muted" x-text="report.frequency"></div>
+              <div class="text-[0.8125rem] font-medium text-text">{{ report.email }}</div>
+              <div class="text-[0.6875rem] text-muted">{{ report.frequency }}</div>
             </div>
             <button class="icon-btn hover:bg-error/15 hover:text-error" @click="deleteEmailReport(report.id)" title="Delete">×</button>
           </div>
@@ -679,8 +679,8 @@ onMount(() => {
           <p x-show="settings().uptimeMonitors.length === 0" class="text-xs text-muted italic">No uptime monitors configured.</p>
           <div x-for="monitor in settings.uptimeMonitors" class="flex justify-between items-center p-2 bg-bg rounded">
             <div class="flex-1 min-w-0">
-              <code class="text-[0.6875rem] text-muted break-all" x-text="monitor.url"></code>
-              <div class="text-[0.6875rem] text-muted" x-text="'Every ' + monitor.interval + 'min • ' + (monitor.status || 'Pending')"></div>
+              <code class="text-[0.6875rem] text-muted break-all">{{ monitor.url }}</code>
+              <div class="text-[0.6875rem] text-muted">{{ 'Every ' + monitor.interval + 'min • ' + (monitor.status || 'Pending') }}</div>
             </div>
             <button class="icon-btn hover:bg-error/15 hover:text-error" @click="deleteUptimeMonitor(monitor.id)" title="Delete">×</button>
           </div>
@@ -700,8 +700,8 @@ onMount(() => {
           <p x-show="settings().teamMembers.length === 0" class="text-xs text-muted italic">No team members added.</p>
           <div x-for="member in settings.teamMembers" class="flex justify-between items-center p-2 bg-bg rounded">
             <div class="flex-1 min-w-0">
-              <div class="text-[0.8125rem] font-medium text-text" x-text="member.email"></div>
-              <div class="text-[0.6875rem] text-muted" x-text="member.role"></div>
+              <div class="text-[0.8125rem] font-medium text-text">{{ member.email }}</div>
+              <div class="text-[0.6875rem] text-muted">{{ member.role }}</div>
             </div>
             <button class="icon-btn hover:bg-error/15 hover:text-error" @click="removeTeamMember(member.id)" title="Remove">×</button>
           </div>
@@ -718,8 +718,8 @@ onMount(() => {
           <p x-show="settings().webhooks.length === 0" class="text-xs text-muted italic">No webhooks configured.</p>
           <div x-for="webhook in settings.webhooks" class="flex justify-between items-center p-2 bg-bg rounded">
             <div class="flex-1 min-w-0">
-              <code class="text-[0.6875rem] text-muted break-all" x-text="webhook.url"></code>
-              <div class="text-[0.6875rem] text-muted" x-text="(webhook.events || []).join(', ')"></div>
+              <code class="text-[0.6875rem] text-muted break-all">{{ webhook.url }}</code>
+              <div class="text-[0.6875rem] text-muted">{{ (webhook.events || []).join(', ') }}</div>
             </div>
             <button class="icon-btn hover:bg-error/15 hover:text-error" @click="deleteWebhook(webhook.id)" title="Delete">×</button>
           </div>
@@ -736,8 +736,8 @@ onMount(() => {
           <p x-show="settings().perfBudgets.length === 0" class="text-xs text-muted italic">No performance budgets set.</p>
           <div x-for="budget in settings.perfBudgets" class="flex justify-between items-center p-2 bg-bg rounded">
             <div class="flex-1 min-w-0">
-              <div class="text-[0.8125rem] font-medium text-text" x-text="budget.metric"></div>
-              <div class="text-[0.6875rem] text-muted" x-text="'Threshold: ' + budget.threshold + (budget.metric === 'CLS' ? '' : 'ms')"></div>
+              <div class="text-[0.8125rem] font-medium text-text">{{ budget.metric }}</div>
+              <div class="text-[0.6875rem] text-muted">{{ 'Threshold: ' + budget.threshold + (budget.metric === 'CLS' ? '' : 'ms') }}</div>
             </div>
             <button class="icon-btn hover:bg-error/15 hover:text-error" @click="deletePerfBudget(budget.id)" title="Delete">×</button>
           </div>

--- a/resources/components/tabs/VitalsTab.stx
+++ b/resources/components/tabs/VitalsTab.stx
@@ -67,18 +67,18 @@ onMount(() => {
       <h4 class="text-sm font-semibold text-error mb-2">Performance Budget Violations</h4>
       <div class="flex flex-col gap-2">
         <div x-for="v in violations" class="text-[0.8125rem] flex gap-2 items-center">
-          <span class="font-semibold text-text" x-text="v.metric"></span>
-          <span class="text-error" x-text="v.currentValue + (v.metric === 'CLS' ? '' : 'ms')"></span>
-          <span class="text-muted" x-text="'(exceeds ' + v.threshold + (v.metric === 'CLS' ? '' : 'ms') + ' by ' + v.exceededBy + (v.metric === 'CLS' ? '' : 'ms') + ')'"></span>
+          <span class="font-semibold text-text">{{ v.metric }}</span>
+          <span class="text-error">{{ v.currentValue + (v.metric === 'CLS' ? '' : 'ms') }}</span>
+          <span class="text-muted">{{ '(exceeds ' + v.threshold + (v.metric === 'CLS' ? '' : 'ms') + ' by ' + v.exceededBy + (v.metric === 'CLS' ? '' : 'ms') + ')' }}</span>
         </div>
       </div>
     </div>
 
     <div class="vitals-grid">
       <div x-for="v in vitals" class="vital-card">
-        <div class="text-xs font-semibold text-muted uppercase tracking-wider mb-1" x-text="v.metric"></div>
-        <div x-class="vitalValueClass(v)" x-text="v.samples > 0 ? formatValue(v.metric, v.p75) : '—'"></div>
-        <div class="text-[0.6875rem] text-muted mb-2" x-text="(v.samples || 0) + ' samples'"></div>
+        <div class="text-xs font-semibold text-muted uppercase tracking-wider mb-1">{{ v.metric }}</div>
+        <div x-class="vitalValueClass(v)">{{ v.samples > 0 ? formatValue(v.metric, v.p75) : '—' }}</div>
+        <div class="text-[0.6875rem] text-muted mb-2">{{ (v.samples || 0) + ' samples' }}</div>
         <div x-show="v.samples > 0" class="h-1 rounded-sm flex overflow-hidden bg-bg">
           <div class="good" x-style="'width: ' + v.good + '%'"></div>
           <div class="needs-improvement" x-style="'width: ' + v.needsImprovement + '%'"></div>


### PR DESCRIPTION
Resolves #119.

stx 0.2.72 fixes the long-standing bug where `{{ }}` rendered as literal text inside client-reactive `:for`/`:if` subtrees (stacksjs/stx#1748 + multi-root setup hydration). This repo already uses `{{ }}` in 220+ places; this brings the remaining `x-text`/`:text` bindings onto the same convention.

### Changes
- **~152 `x-text`/`:text` bindings → `{{ }}`** across 29 `resources` views/components. Every site sits on/under a client `x-for`/`:if` and reads a signal, derived, or loop var.
- Bumps `@stacksjs/{stx,components}`, `bun-plugin-stx` to `^0.2.72` (the migration depends on it).

### Not touched
- Pre-existing `{{ }}` in `<option>`/`<title>` left exactly as-is (text-only elements).
- `StatsRow`'s `<div x-text="statValue(stat.id)">—</div>` keeps `x-text` — it has a meaningful em-dash SSR fallback and the expression carries no inline default.
- No `:html`/`x-html` in this repo; no server `@foreach`/`@if` bindings touched.

### Verification
Rendered the touched pages (`FiltersBar`, `StatsRow`, `base` layout, plus `SettingsTab`/`ErrorDetail`) through `processDirectives` — the framework's render path: all process cleanly, with **zero invalid `<option><span>` / `<title><span>`** and no net change to any text-only element. Framework-level reactive hydration of `{{ }}` under `:for`/`:if` was independently confirmed in a real browser (headless Chrome via CDP) on stx 0.2.72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)