### PR TITLE
refactor: finish DataTable :text → {{ }} migration

### DIFF
--- a/src/dashboard/components/DataTable.stx
+++ b/src/dashboard/components/DataTable.stx
@@ -161,7 +161,7 @@ const columnsJson = JSON.stringify(columns)
                 @click="toggleSort(column.key)"
               >
                 <div class="flex items-center gap-1" x-class="{ 'justify-end': column.align === 'right' }">
-                  <span :text="column.label"></span>
+                  <span>{{ column.label }}</span>
                   <svg
                     :show="sortKey() === column.key"
                     class="w-4 h-4"
@@ -188,8 +188,7 @@ const columnsJson = JSON.stringify(columns)
                     'text-center': column.align === 'center',
                     'tabular-nums': column.format === 'number' || column.format === 'currency'
                   }"
-                  :text="formatValueClient(row[column.key], column.format)"
-                ></td>
+                >{{ formatValueClient(row[column.key], column.format) }}</td>
               </div>
             </tr>
           </div>
@@ -198,7 +197,7 @@ const columnsJson = JSON.stringify(columns)
 
       <div :show="totalPagesComputed() >= 2" class="flex items-center justify-between mt-4 pt-4 border-t border-gray-200">
         <div class="text-sm text-gray-500">
-          Showing <span :text="(currentPage() - 1) * tablePgSize + 1"></span> to <span :text="Math.min(currentPage() * tablePgSize, tableRows.length)"></span> of <span :text="tableRows.length"></span>
+          Showing <span>{{ (currentPage() - 1) * tablePgSize + 1 }}</span> to <span>{{ Math.min(currentPage() * tablePgSize, tableRows.length) }}</span> of <span>{{ tableRows.length }}</span>
         </div>
         <div class="flex items-center gap-2">
           <button
@@ -210,7 +209,7 @@ const columnsJson = JSON.stringify(columns)
             <Icon name="chevron-left" size="20" />
           </button>
           <span class="text-sm text-gray-600">
-            Page <span :text="currentPage()"></span> of <span :text="totalPagesComputed()"></span>
+            Page <span>{{ currentPage() }}</span> of <span>{{ totalPagesComputed() }}</span>
           </span>
           <button
             type="button"


### PR DESCRIPTION
Completes the `:text` → `{{ }}` stragglers in `DataTable.stx` that the original sweep ([#120](https://github.com/stacksjs/ts-analytics/pull/120)) missed:

- 4 inline `<span :text="…"></span>` inside mixed text ("Showing X to Y of Z", "Page X of Y")
- 2 `<span :text="column.label">` / `<td :text="…">` (one a multi-line attribute)

**Why this one is safe** (unlike the `@include` partials in other repos): `DataTable.stx`'s body keeps `:for` / `:show` / `:key`, so `usesSignalsInScript` stays true even when the component's `<script>` is stripped at render time. Verified the `{{ }}` are preserved 5/5 server-side.

Context: the broader investigation found `{{ }}` is **not** safe in `@include` partials/components whose script is stripped before expression processing — see stacksjs/stx#1758. That's why this PR is scoped to just DataTable (which trips the gate via its structural directives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)