### PR TITLE
feat(stx): one-line stx integration (plugins: ['@stacksjs/ts-analytics']) + fix library build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.tgz
 coverage
 dist
+dist-site
 lib-cov
 logs
 node_modules

--- a/README.md
+++ b/README.md
@@ -41,6 +41,31 @@ The validated pattern for adding ts-analytics to any site (docs sites included):
 
 3. **Optional hardening**: append `?stealth=true` for the unlisted beacon path, or serve it first-party from your own domain — see the [ad-blocker resilience guide](docs/guide/tracking-script.md#ad-blocker-resilience-first-party-proxy). Error tracking without analytics: grab the DSN + SDK snippet from the same Settings page.
 
+### stx framework (one config line)
+
+On an [stx](https://github.com/stacksjs/stx) app there's no `index.html` to paste a snippet into. Add the plugin and your app ID — that's the whole install (mirrors `nuxt-fathom`):
+
+```ts
+// stx.config.ts
+export default {
+  plugins: ['@stacksjs/ts-analytics'],
+  analytics: {
+    appId: 'YOUR_APP_ID',
+    // apiEndpoint defaults to '/api/analytics' (events POST to `${apiEndpoint}/collect`)
+  },
+}
+```
+
+It injects the SPA-aware tracker before `</head>` on every server-rendered page — pageviews fire on the first load **and** on client-side (`<StxLink>`) navigations, since the tracker patches `history.pushState`.
+
+You can also pass options inline: `plugins: [['@stacksjs/ts-analytics', { appId: 'YOUR_APP_ID' }]]`.
+
+Notes:
+
+- **The plugin is the package's default export**, so `plugins: ['@stacksjs/ts-analytics']` resolves to it directly. Non-stx code should use the **named** exports (`import { Analytics } from '@stacksjs/ts-analytics'`).
+- **It owns the `analytics` config key** and is mutually exclusive with stx's native single-driver analytics — if you've set `analytics.driver` to a native provider (`fathom`, `plausible`, …), ts-analytics backs off (and logs a warning).
+- **Mount a collector** for `${apiEndpoint}/collect` (e.g. `mountAnalyticsRoutes` / `createBunRouter` from this package), or point `apiEndpoint` at a hosted ts-analytics instance — otherwise beacons hit a 404.
+
 ## Quick Start
 
 ### 1. Set Up the Analytics Store

--- a/build-site.ts
+++ b/build-site.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+/**
+ * Static dashboard SITE build (deploy artifact for Netlify / Vercel / S3 /
+ * the lambda views) → dist-site/. This is NOT the npm package output — the
+ * importable library is built by build.ts (`bun run build`) into dist/.
+ *
+ * Run with `bun run build:site`.
+ */
+import { generateStaticSite } from '@stacksjs/stx/ssg'
+
+await generateStaticSite({
+  pagesDir: 'pages',
+  outputDir: 'dist-site',
+  publicDir: 'public',
+  sitemap: true,
+  cleanOutput: true,
+})

--- a/build.ts
+++ b/build.ts
@@ -1,10 +1,50 @@
 #!/usr/bin/env bun
-import { generateStaticSite } from '@stacksjs/stx/ssg'
+/**
+ * Library build — emits dist/index.js (+ every module under ./*) and
+ * declarations, so `@stacksjs/ts-analytics` is importable as a package
+ * (package.json `module`/`exports`/`types` all point at ./dist).
+ *
+ * The static dashboard SITE is a separate deploy artifact — see build-site.ts
+ * (`bun run build:site` → dist-site/). Keeping them apart stops the SSG's
+ * cleanOutput from wiping the library and vice-versa.
+ *
+ * Mirrors the sibling stacks library builds: every source module is built so
+ * the `./*` subpath export resolves to real JS (not just a .d.ts stub), with
+ * node_modules left external (`packages: 'external'`).
+ */
+import { rmSync } from 'node:fs'
+import { dts } from 'bun-plugin-dtsx'
+import stx from 'bun-plugin-stx'
 
-await generateStaticSite({
-  pagesDir: 'pages',
-  outputDir: 'dist',
-  publicDir: 'public',
-  sitemap: true,
-  cleanOutput: true,
+rmSync('./dist', { recursive: true, force: true })
+
+// Build from the public entry only and let Bun follow the import graph, so the
+// dashboard-UI shims (src/components/dashboard re-exports repo-root `.stx`) that
+// aren't part of the library API are excluded automatically. `splitting` keeps
+// shared code in chunks instead of duplicating it into index.js.
+const result = await Bun.build({
+  entrypoints: ['./src/index.ts'],
+  splitting: true,
+  outdir: './dist',
+  root: './src',
+  // bun-plugin-stx resolves the `.stx` imports a few library modules carry
+  // (e.g. handlers render dashboard views server-side); dts() emits declarations.
+  plugins: [stx(), dts()],
+  target: 'bun',
+  format: 'esm',
+  packages: 'external',
 })
+
+if (!result.success) {
+  console.error('[ts-analytics] library build failed:')
+  for (const log of result.logs)
+    console.error(log)
+  process.exit(1)
+}
+
+const hasIndex = await Bun.file('./dist/index.js').exists()
+if (!hasIndex) {
+  console.error('[ts-analytics] build succeeded but dist/index.js is missing — check src/index.ts')
+  process.exit(1)
+}
+console.log(`[ts-analytics] library built → dist/ (${result.outputs.length} files, dist/index.js present)`)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "analytics": "bun ./bin/cli.ts",
     "build": "bun build.ts",
+    "build:site": "bun build-site.ts",
     "preview": "bun preview.ts",
     "dev": "bun --watch serve.ts",
     "dev:server": "bun --watch ./server/index.ts",

--- a/preview.ts
+++ b/preview.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env bun
 /**
- * Serves the static `dist/` build locally for testing before deploying
- * to Netlify / Vercel / S3. Plain file server, no processing.
+ * Serves the static site build (`dist-site/`, produced by `bun run build:site`)
+ * locally for testing before deploying to Netlify / Vercel / S3. Plain file
+ * server, no processing. (The npm library build lives in `dist/` — see build.ts.)
  *
  * Usage: bun run preview
  */
 
 const port = Number(process.argv[2]) || 3001
-const distDir = 'dist'
+const distDir = 'dist-site'
 
 Bun.serve({
   port,

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,3 +363,8 @@ export {
   lookupFromHeaders,
   lookupIP,
 } from './geolocation'
+
+// stx integration. The plugin is the package's DEFAULT export so stx resolves
+// `plugins: ['@stacksjs/ts-analytics']` to it directly (no subpath). Config is
+// read from the top-level `analytics: { appId }` key. See ./integrations/stx.
+export { default, type StxAnalyticsConfig, stxPlugin } from './integrations/stx'

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -18,3 +18,8 @@ export {
   type CloudflareHandlerOptions,
   type StorageAdapter,
 } from './cloudflare'
+
+export {
+  default as stxPlugin,
+  type StxAnalyticsConfig,
+} from './stx'

--- a/src/integrations/stx.ts
+++ b/src/integrations/stx.ts
@@ -1,0 +1,153 @@
+/**
+ * stx integration for ts-analytics.
+ *
+ * The whole install is: add the plugin and give it your app ID — mirroring
+ * the nuxt-fathom one-liner (register the module + provide an ID).
+ *
+ * ```ts
+ * // stx.config.ts
+ * export default {
+ *   plugins: ['@stacksjs/ts-analytics'],
+ *   analytics: {
+ *     appId: 'YOUR_APP_ID',
+ *     // apiEndpoint defaults to '/api/analytics'
+ *   },
+ * }
+ * ```
+ *
+ * It injects ts-analytics' SPA-aware tracking script before `</head>` on every
+ * server-rendered page. The tracker patches `history.pushState`/`replaceState`,
+ * so it counts client-side (SPA) navigations after the first load — not just
+ * full reloads. This is exposed as the package's DEFAULT export, so stx
+ * resolves `plugins: ['@stacksjs/ts-analytics']` to it directly (no subpath).
+ *
+ * Config is read from the top-level `analytics` key (the same way nuxt-fathom
+ * reads `fathom:`); you can also pass options inline on the plugin entry:
+ *
+ * ```ts
+ * plugins: [['@stacksjs/ts-analytics', { appId: 'YOUR_APP_ID' }]]
+ * ```
+ */
+import type { TrackingScriptConfig } from '../tracking-script'
+import { generateFullTrackingScript } from '../tracking-script'
+
+/**
+ * ts-analytics config for stx — the shape of the top-level `analytics` key.
+ * Extends the tracker config but swaps the internal `siteId` for the
+ * consumer-facing `appId`, and adds an `apiEndpoint` default.
+ */
+export interface StxAnalyticsConfig extends Partial<Omit<TrackingScriptConfig, 'siteId' | 'apiEndpoint'>> {
+  /** Your ts-analytics app ID (the site/app identifier). Required to track. */
+  appId?: string
+  /** Collector base URL. POSTs land at `${apiEndpoint}/collect`. Default: `/api/analytics`. */
+  apiEndpoint?: string
+  /** Set `false` to disable without removing the plugin from the list. */
+  enabled?: boolean
+}
+
+/** Minimal shape of the stx plugin setup context (avoids a hard dep on stx types). */
+interface StxPluginContext {
+  config?: {
+    analytics?: StxAnalyticsConfig & {
+      enabled?: boolean
+      driver?: string
+      custom?: { inlineScript?: string, scriptUrl?: string, __tsAnalytics?: boolean }
+    }
+  } & Record<string, unknown>
+}
+
+/**
+ * The stx plugin object. Exported by name for explicit imports; also the
+ * package default export (see `src/index.ts`) so `plugins: ['@stacksjs/ts-analytics']`
+ * resolves to it.
+ */
+export const stxPlugin = {
+  name: 'ts-analytics',
+  setup(options: StxAnalyticsConfig | undefined, stx: StxPluginContext): void {
+    // Merge the top-level `analytics` config with any inline plugin options
+    // (inline wins). Makes BOTH styles work:
+    //   plugins: ['@stacksjs/ts-analytics'], analytics: { appId }
+    //   plugins: [['@stacksjs/ts-analytics', { appId }]]
+    const cfg: StxAnalyticsConfig = { ...(stx.config?.analytics ?? {}), ...(options ?? {}) }
+
+    if (cfg.enabled === false)
+      return
+
+    const appId = cfg.appId ?? (cfg as { siteId?: string }).siteId
+    if (!appId) {
+      console.warn(
+        '[ts-analytics] no `appId` configured — add `analytics: { appId: \'…\' }` to stx.config.ts. Skipping tracker injection.',
+      )
+      return
+    }
+
+    // Validate before these values get interpolated into the inline tracker.
+    // They're developer config, but a stray quote/backslash/newline would
+    // silently break the whole tracker, and a `</script>` would close the
+    // injected <script> element (the HTML parser ignores JS string context).
+    // Warn-and-skip — matching the missing-appId path — beats a broken page.
+    if (!/^[\w.-]+$/.test(String(appId))) {
+      console.warn(
+        `[ts-analytics] appId '${appId}' has unexpected characters (allowed: A–Z a–z 0–9 . _ -). Skipping tracker injection.`,
+      )
+      return
+    }
+    // Strip trailing slashes so we never emit `${apiEndpoint}//collect`, then
+    // reject anything that could still break out of the literal / <script>.
+    const apiEndpoint = (cfg.apiEndpoint ?? '/api/analytics').replace(/\/+$/, '')
+    if (/[<>"'\\\n\r]/.test(apiEndpoint)) {
+      console.warn(
+        `[ts-analytics] apiEndpoint '${apiEndpoint}' contains unsafe characters. Skipping tracker injection.`,
+      )
+      return
+    }
+
+    // Everything except the integration-only keys flows through to the tracker
+    // (honorDnt, trackOutboundLinks, heatmap, excludePaths, …). `siteId` is
+    // dropped explicitly so a stray value can't shadow appId regardless of key order.
+    const { appId: _appId, apiEndpoint: _apiEndpoint, enabled: _enabled, siteId: _siteId, ...trackerOpts }
+      = cfg as StxAnalyticsConfig & { siteId?: string }
+    const trackerJs = generateFullTrackingScript({
+      autoPageView: true,
+      ...trackerOpts,
+      siteId: appId,
+      apiEndpoint,
+    })
+
+    // stx's native analytics injection (injectAnalytics) is the right home for
+    // this: it runs at process.ts ~1356, and the client-script transform runs
+    // LATER (~1482). So our injected inline <script> IS re-wrapped into a
+    // `<script data-stx-scoped>;(function(){'use strict'; … })()`, and because
+    // the SPA fragment extractor re-runs every data-stx-scoped script, it is
+    // re-executed on every client-side navigation. That re-execution is exactly
+    // why the `if(!window.__tsAnalytics)` guard below is LOAD-BEARING (not
+    // defensive): it keeps history.pushState patched once and avoids
+    // double-counting. (The wrapper carries no `window.stx` destructure, so it's
+    // safe on no-signals pages.) We adapt the simple `{ appId }` config into
+    // stx's single-driver native analytics: { enabled, driver:'custom', custom }.
+    stx.config ??= {}
+    stx.config.analytics ??= {}
+    const a = stx.config.analytics
+    // Evaluate the conflict against the EFFECTIVE config (analytics + inline
+    // options), and treat our own prior injection as a no-op — so HMR / a re-run
+    // of setup neither warns nor double-injects.
+    const effectiveDriver = (cfg as { driver?: string }).driver
+    if ((effectiveDriver && effectiveDriver !== 'custom') || (a.custom && !a.custom.__tsAnalytics)) {
+      console.warn(
+        `[ts-analytics] a native analytics provider is already configured (${effectiveDriver ? `driver: '${effectiveDriver}'` : 'analytics.custom'}); ts-analytics tracker NOT injected.`,
+      )
+      return
+    }
+    a.enabled = true
+    a.driver = 'custom'
+    // if-block guard (not a top-level `return`, which is illegal inside <script>);
+    // load-bearing — see above. `__tsAnalytics: true` marks the block as ours so
+    // a re-run of setup is an idempotent no-op.
+    a.custom = {
+      __tsAnalytics: true,
+      inlineScript: `if(!window.__tsAnalytics){window.__tsAnalytics=1;\n${trackerJs}\n}`,
+    }
+  },
+}
+
+export default stxPlugin

--- a/src/tracking-script.ts
+++ b/src/tracking-script.ts
@@ -187,10 +187,14 @@ function buildScript(config: TrackingScriptConfig): string {
 }
 
 function buildConfigSection(config: TrackingScriptConfig): string {
+  // JSON.stringify the string values (matching excludePaths below) so a quote,
+  // backslash, or newline in siteId/apiEndpoint can't break out of the literal
+  // and corrupt the whole inline tracker. (A literal `</script>` still has to be
+  // rejected upstream — the HTML parser closes <script> regardless of JS context.)
   return `// Configuration
 var CONFIG = {
-  siteId: '${config.siteId}',
-  endpoint: '${config.apiEndpoint}/collect',
+  siteId: ${JSON.stringify(config.siteId)},
+  endpoint: ${JSON.stringify(`${config.apiEndpoint}/collect`)},
   honorDnt: ${config.honorDnt ?? true},
   sessionTimeout: ${(config.sessionTimeout ?? 30) * 60 * 1000},
   debug: ${config.debug ?? false},

--- a/test/stx-integration.test.ts
+++ b/test/stx-integration.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test'
+import { processDirectives } from '@stacksjs/stx'
+import stxPlugin from '../src/integrations/stx'
+
+// The plugin adapts `{ appId }` into stx's native single-driver analytics
+// (enabled + driver:'custom' + custom.inlineScript) so the tracker injects via
+// injectAnalytics. stx reprocesses that inline <script> into a data-stx-scoped
+// IIFE and re-runs it on every SPA navigation — so the `if(!window.__tsAnalytics)`
+// guard is LOAD-BEARING. These tests pin that contract (and would have caught
+// the inverted-comment drift the review flagged).
+function setup(analytics: Record<string, unknown>, options?: Record<string, unknown>) {
+  const config: any = { analytics }
+  stxPlugin.setup(options as any, { config })
+  return config
+}
+
+describe('ts-analytics stx integration', () => {
+  it('adapts { appId } into native analytics and injects the tracker before </head>', async () => {
+    const config = setup({ appId: 'app_123' })
+    expect(config.analytics.enabled).toBe(true)
+    expect(config.analytics.driver).toBe('custom')
+    expect(config.analytics.custom.inlineScript).toContain('app_123')
+    expect(config.analytics.custom.inlineScript).toContain('/api/analytics/collect')
+
+    const page = `<!doctype html><html><head><title>D</title></head><body></body></html>`
+    const out = await processDirectives(page, {}, 'page.stx', config, new Set())
+    const tracker = out.indexOf('__tsAnalytics')
+    expect(tracker).toBeGreaterThan(-1)
+    expect(tracker).toBeLessThan(out.indexOf('</head>'))
+  })
+
+  it('wraps the tracker in the load-bearing idempotency guard', () => {
+    const config = setup({ appId: 'app_g' })
+    expect(config.analytics.custom.inlineScript.startsWith('if(!window.__tsAnalytics)')).toBe(true)
+    expect(config.analytics.custom.__tsAnalytics).toBe(true)
+  })
+
+  it('normalizes a trailing slash on apiEndpoint (no //collect)', () => {
+    const s = setup({ appId: 'x', apiEndpoint: '/api/analytics/' }).analytics.custom.inlineScript
+    expect(s).toContain('/api/analytics/collect')
+    expect(s).not.toContain('//collect')
+  })
+
+  it('rejects an appId / apiEndpoint that could break out of the inline script', () => {
+    expect(setup({ appId: 'x\');alert(1)//' }).analytics.custom).toBeUndefined()
+    expect(setup({ appId: 'ok', apiEndpoint: '/a</script>' }).analytics.custom).toBeUndefined()
+  })
+
+  it('is an idempotent no-op when setup runs again (HMR / re-load)', () => {
+    const config: any = { analytics: { appId: 'app_r' } }
+    stxPlugin.setup(undefined, { config })
+    const first = config.analytics.custom.inlineScript
+    stxPlugin.setup(undefined, { config })
+    expect(config.analytics.custom.inlineScript).toBe(first)
+  })
+
+  it('skips when no appId is configured, and backs off an explicit native driver', () => {
+    expect(setup({}).analytics.custom).toBeUndefined()
+    expect(setup({ appId: 'x' }, { appId: 'x', driver: 'fathom' }).analytics.custom).toBeUndefined()
+  })
+
+  it('is exposed as the package default export (plugins: [\'@stacksjs/ts-analytics\'])', () => {
+    expect(stxPlugin.name).toBe('ts-analytics')
+    expect(typeof stxPlugin.setup).toBe('function')
+  })
+})


### PR DESCRIPTION
Replicates the `nuxt-fathom` one-liner for stx: add the plugin, give it an `appId`, done.

```ts
// stx.config.ts
export default {
  plugins: ['@stacksjs/ts-analytics'],
  analytics: { appId: 'YOUR_APP_ID' },   // apiEndpoint defaults to /api/analytics
}
```

Injects the SPA-aware tracker before `</head>` on every SSR page (pageviews on first load **and** `<StxLink>` navigations via the `history.pushState` patch).

## What's in here

**The plugin** (`src/integrations/stx.ts`, the package **default** export so the bare specifier resolves). Reads `appId` from the top-level `analytics` key (nuxt-fathom style) or inline plugin options, and adapts it into stx's native single-driver analytics (`enabled` + `driver:'custom'` + `custom.inlineScript`) so injection runs via `injectAnalytics` — **after** stx's client-script pass. Because stx re-wraps + re-runs that inline script on SPA nav, the `if(!window.__tsAnalytics)` guard is **load-bearing**.

**Library build fix (blocker).** `build.ts` was `generateStaticSite({ outputDir: 'dist' })` — so `dist/` was an SSG *website* with **no `dist/index.js`**, even though `module`/`exports`/`types` point there. The package wasn't importable and the plugin couldn't load. `build.ts` now does a real `Bun.build` (+ `bun-plugin-dtsx`) → `dist/index.js` + declarations; the dashboard site moves to `bun run build:site` → `dist-site/` (`preview.ts` follows). The lambda deploy is unaffected (it uses `scripts/build-views.ts`).

**Review hardening.** `JSON.stringify` `siteId`/`apiEndpoint` in the tracker config (was raw single-quote interpolation — a quote/`</script>`/newline breakout for *every* `generateFullTrackingScript` consumer, the one path stx didn't already escape); validate `appId`/`apiEndpoint` (warn-and-skip); trailing-slash normalize; `siteId` strip; self-tagged idempotent re-run.

## Verification
- `bun run build` → `dist/index.js` (321 KB) + `dist/index.d.ts`; the built package's default export is the plugin (`name: 'ts-analytics'` + `setup`), named `stxPlugin` + all platform exports intact.
- `test/stx-integration.test.ts` — 7 cases green against the **installed** `@stacksjs/stx`.
- Existing analytics tests: 188 pass / 0 fail (the escaping change is format-compatible).

## Notes for reviewers
- The plugin is the package's **first default export** — non-stx consumers should use named exports. Documented in the README.
- It **owns the `analytics` key** and backs off if you've set a native `driver`.
- The tracker POSTs to `${apiEndpoint}/collect` — mount a collector or point at a hosted instance (README note).
- Pairs with stacksjs/stx (bun-plugin serve path) — separate PR so the tracker also injects on `stx-serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)