### PR TITLE
fix: emit a real library build (dist/index.js + ./stx) so the package is importable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.tgz
 coverage
 dist
+dist-site
 lib-cov
 logs
 node_modules

--- a/build-site.ts
+++ b/build-site.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+/**
+ * Static dashboard SITE build (deploy artifact for Netlify / Vercel / S3) →
+ * dist-site/. This is NOT the npm package output — the importable library is
+ * built by build.ts (`bun run build`) into dist/.
+ *
+ * Run with `bun run build:site`.
+ */
+import { generateStaticSite } from '@stacksjs/stx/ssg'
+
+await generateStaticSite({
+  pagesDir: 'pages',
+  outputDir: 'dist-site',
+  publicDir: 'public',
+  sitemap: true,
+  cleanOutput: true,
+})

--- a/build.ts
+++ b/build.ts
@@ -1,10 +1,46 @@
 #!/usr/bin/env bun
-import { generateStaticSite } from '@stacksjs/stx/ssg'
+/**
+ * Library build — emits the package's JS + declarations so `@stacksjs/ts-analytics`
+ * is importable (package.json's `module`/`exports`/`types` all point at ./dist).
+ *
+ * Builds two entrypoints so both exports resolve:
+ *   `.`     → dist/index.js + dist/index.d.ts
+ *   `./stx` → dist/integrations/stx.js + dist/integrations/stx.d.ts  (the tsAnalytics() module)
+ *
+ * The static dashboard SITE is a separate deploy artifact — `bun run build:site`
+ * (build-site.ts → dist-site/). Keeping them apart stops the SSG's cleanOutput
+ * from wiping the library and vice-versa. node_modules stays external.
+ */
+import { rmSync } from 'node:fs'
+import { dts } from 'bun-plugin-dtsx'
+import stx from 'bun-plugin-stx'
 
-await generateStaticSite({
-  pagesDir: 'pages',
-  outputDir: 'dist',
-  publicDir: 'public',
-  sitemap: true,
-  cleanOutput: true,
+rmSync('./dist', { recursive: true, force: true })
+
+const result = await Bun.build({
+  entrypoints: ['./src/index.ts', './src/integrations/stx.ts'],
+  splitting: true,
+  outdir: './dist',
+  root: './src',
+  // bun-plugin-stx resolves the `.stx` imports a few library modules carry
+  // (e.g. handlers render dashboard views server-side); dts() emits declarations.
+  plugins: [stx(), dts()],
+  target: 'bun',
+  format: 'esm',
+  packages: 'external',
 })
+
+if (!result.success) {
+  console.error('[ts-analytics] library build failed:')
+  for (const log of result.logs)
+    console.error(log)
+  process.exit(1)
+}
+
+for (const f of ['./dist/index.js', './dist/integrations/stx.js']) {
+  if (!(await Bun.file(f).exists())) {
+    console.error(`[ts-analytics] build succeeded but ${f} is missing — check the entrypoints/exports`)
+    process.exit(1)
+  }
+}
+console.log(`[ts-analytics] library built → dist/ (${result.outputs.length} files; index.js + integrations/stx.js present)`)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "scripts": {
     "analytics": "bun ./bin/cli.ts",
     "build": "bun build.ts",
+    "build:site": "bun build-site.ts",
     "preview": "bun preview.ts",
     "dev": "bun --watch serve.ts",
     "dev:server": "bun --watch ./server/index.ts",

--- a/preview.ts
+++ b/preview.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env bun
 /**
- * Serves the static `dist/` build locally for testing before deploying
- * to Netlify / Vercel / S3. Plain file server, no processing.
+ * Serves the static site build (`dist-site/`, produced by `bun run build:site`)
+ * locally for testing before deploying to Netlify / Vercel / S3. Plain file
+ * server, no processing. (The npm library build lives in `dist/` — see build.ts.)
  *
  * Usage: bun run preview
  */
 
 const port = Number(process.argv[2]) || 3001
-const distDir = 'dist'
+const distDir = 'dist-site'
 
 Bun.serve({
   port,

--- a/src/tracking-script.ts
+++ b/src/tracking-script.ts
@@ -187,10 +187,13 @@ function buildScript(config: TrackingScriptConfig): string {
 }
 
 function buildConfigSection(config: TrackingScriptConfig): string {
+  // JSON.stringify the string values (matching excludePaths below) so a quote,
+  // backslash, or newline in siteId/apiEndpoint can't break out of the literal
+  // and corrupt the whole inline tracker.
   return `// Configuration
 var CONFIG = {
-  siteId: '${config.siteId}',
-  endpoint: '${config.apiEndpoint}/collect',
+  siteId: ${JSON.stringify(config.siteId)},
+  endpoint: ${JSON.stringify(`${config.apiEndpoint}/collect`)},
   honorDnt: ${config.honorDnt ?? true},
   sessionTimeout: ${(config.sessionTimeout ?? 30) * 60 * 1000},
   debug: ${config.debug ?? false},


### PR DESCRIPTION
`build.ts` was `generateStaticSite({ outputDir: 'dist' })` — a static dashboard *site*, not a library. So `dist/` had only `404.html` + assets, and the entry points `package.json` references (`module`/`exports`/`types` → `dist/index.js`, `dist/integrations/stx.js`, `dist/index.d.ts`) **never existed**. Neither `@stacksjs/ts-analytics` nor `@stacksjs/ts-analytics/stx` (the `tsAnalytics()` module from #0047f42) was importable once installed/published — it only worked from source.

## Fix
- `build.ts` → `Bun.build` over the `.` and `./stx` entrypoints (`src/index.ts` + `src/integrations/stx.ts`), `bun-plugin-dtsx` for declarations, `packages: 'external'` → `dist/index.js` + `dist/integrations/stx.js` + both `.d.ts`.
- Dashboard **site** moves to `bun run build:site` → `dist-site/` (so the SSG's `cleanOutput` stops wiping the library). `preview.ts` follows. **Lambda deploy untouched** — it uses `scripts/build-views.ts`.
- **Tracker hardening**: `JSON.stringify` `siteId`/`apiEndpoint` in `buildConfigSection` (was raw single-quote interpolation — a quote/`</script>`/newline breakout for any inline-tracker consumer).

## Verified
- `bun run build` → `dist/index.js` + `dist/integrations/stx.js` + both `.d.ts`.
- `@stacksjs/ts-analytics/stx` resolves `tsAnalytics`/`tsAnalyticsTag`; `tsAnalyticsTag({ appId: 'bench-review', apiEndpoint: 'http://localhost:2027' })` → `<script defer data-site="bench-review" src="http://localhost:2027/script.js"></script>`.
- Existing analytics tests: 157 pass / 0 fail.

Stacks on top of your `feat(integrations) 0047f42` (the `tsAnalytics()` integration) — this just makes it shippable.